### PR TITLE
feat: interpolant bridge drifts and bridge-matching implementation

### DIFF
--- a/src/nami/interpolants/__init__.py
+++ b/src/nami/interpolants/__init__.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 from .gamma import BrownianGamma, GammaSchedule, ScaledBrownianGamma, ZeroGamma
-from .transforms import DriftFromVelocityScore, MirrorVelocityFromScore, ScoreFromNoise
+from .transforms import (
+    DriftFromVelocityScore,
+    MarkovizationDriftFromVelocityScore,
+    MirrorVelocityFromScore,
+    ScoreFromNoise,
+)
 
 __all__ = [
     "BrownianGamma",
     "DriftFromVelocityScore",
     "GammaSchedule",
+    "MarkovizationDriftFromVelocityScore",
     "MirrorVelocityFromScore",
     "ScaledBrownianGamma",
     "ScoreFromNoise",

--- a/src/nami/interpolants/gamma.py
+++ b/src/nami/interpolants/gamma.py
@@ -47,6 +47,15 @@ class BrownianGamma(GammaSchedule):
 
 @dataclass(frozen=True)
 class ScaledBrownianGamma(GammaSchedule):
+    """Brownian gamma schedule with variance scale.
+
+    The schedule is
+    ``gamma(t)^2 = scale * t * (1 - t)``.
+    For bridge paths parameterised by ``sigma`` where
+    ``gamma(t) = sigma * sqrt(t * (1 - t))``,
+    use ``scale = sigma**2`` (or ``from_sigma``).
+    """
+
     scale: float = 1.0
     eps: float = 1e-12
 
@@ -54,6 +63,14 @@ class ScaledBrownianGamma(GammaSchedule):
         if self.scale <= 0:
             msg = "scale must be positive"
             raise ValueError(msg)
+
+    @classmethod
+    def from_sigma(cls, sigma: float, eps: float = 1e-12) -> ScaledBrownianGamma:
+        """Construct a schedule with ``gamma(t) = sigma * sqrt(t * (1 - t))``."""
+        if sigma <= 0:
+            msg = "sigma must be positive"
+            raise ValueError(msg)
+        return cls(scale=float(sigma) ** 2, eps=eps)
 
     def gamma(self, t: torch.Tensor) -> torch.Tensor:
         return torch.sqrt(torch.clamp(self.scale * t * (1 - t), min=self.eps))

--- a/src/nami/interpolants/transforms.py
+++ b/src/nami/interpolants/transforms.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import torch
 from torch import nn
 
@@ -26,7 +28,26 @@ def _expand_time_like(
 
 
 class ScoreFromNoise(nn.Module):
-    """Convert a noise-prediction model eta(x, t) into a score model s(x, t)."""
+    """Convert a noise-prediction model eta(x, t) into a score model s(x, t).
+
+    Parameters
+    ----------
+    eta_model : nn.Module
+        The noise prediction model that takes (x, t, c) and returns noise.
+    gamma_schedule : [GammaSchedule]
+        The noise schedule for converting noise to score.
+    eps : float, optional
+        Small epsilon value to prevent division by zero, by default 1e-12.
+
+    Attributes
+    ----------
+    eta_model : nn.Module
+        The wrapped noise prediction model.
+    gamma_schedule : GammaSchedule
+        The noise schedule.
+    eps : float
+        Numerical stability constant.
+    """
 
     def __init__(
         self, eta_model: nn.Module, gamma_schedule: GammaSchedule, eps: float = 1e-12
@@ -50,7 +71,29 @@ class ScoreFromNoise(nn.Module):
 
 
 class DriftFromVelocityScore(nn.Module):
-    """Combine velocity and score into drift b(x, t) = v + gamma*gamma_dot*s."""
+    """Combine velocity and score into probability-flow drift.
+
+    Computes ``u(x, t) = v(x, t) - gamma(t) * gamma_dot(t) * s(x, t)``.
+    For markovization SDE drift use ``MarkovizationDriftFromVelocityScore``.
+
+    Parameters
+    ----------
+    velocity_model : nn.Module
+        The velocity field model v(x, t, c).
+    score_model : nn.Module
+        The score field model s(x, t, c).
+    gamma_schedule : GammaSchedule
+        The noise schedule providing gamma(t) and gamma_dot(t).
+
+    Attributes
+    ----------
+    velocity_model : nn.Module
+        The velocity field model.
+    score_model : nn.Module
+        The score field model.
+    gamma_schedule : GammaSchedule
+        The noise schedule.
+    """
 
     def __init__(
         self,
@@ -70,11 +113,72 @@ class DriftFromVelocityScore(nn.Module):
     def forward(
         self, x: torch.Tensor, t: torch.Tensor, c: torch.Tensor | None = None
     ) -> torch.Tensor:
+        """Compute the probability-flow drift.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            The state variable.
+        t : torch.Tensor
+            The time variable.
+        c : torch.Tensor or None, optional
+            Optional conditioning information, by default None.
+
+        Returns
+        -------
+        torch.Tensor
+            The drift value u(x, t) = v(x, t) - gamma*gamma_dot*s(x, t).
+        """
         v_val = self.velocity_model(x, t, c)
         s_val = self.score_model(x, t, c)
         gg_val = self.gamma_schedule.gamma_gamma_dot(t)
         gg_val = _expand_time_like(gg_val, s_val, self.event_ndim)
-        return v_val + gg_val * s_val
+        return v_val - gg_val * s_val
+
+
+class MarkovizationDriftFromVelocityScore(nn.Module):
+    """Combine velocity and score into markovization SDE drift.
+
+    Computes
+    ``b(x, t) = u(x, t) + 0.5 * g(t)^2 * s(x, t)``,
+    where ``u(x, t) = v(x, t) - gamma(t) * gamma_dot(t) * s(x, t)``.
+    Equivalently:
+    ``b(x, t) = v(x, t) + (-gamma*gamma_dot + 0.5*g^2) * s(x, t)``.
+    """
+
+    def __init__(
+        self,
+        velocity_model: nn.Module,
+        score_model: nn.Module,
+        gamma_schedule: GammaSchedule,
+        *,
+        diffusion2: float | Callable[[torch.Tensor], torch.Tensor],
+    ):
+        super().__init__()
+        self.velocity_model = velocity_model
+        self.score_model = score_model
+        self.gamma_schedule = gamma_schedule
+        self.diffusion2 = diffusion2
+
+    @property
+    def event_ndim(self) -> int | None:
+        return getattr(self.velocity_model, "event_ndim", None)
+
+    def _diffusion2(self, t: torch.Tensor) -> torch.Tensor:
+        if callable(self.diffusion2):
+            return self.diffusion2(t)
+        return torch.full_like(t, float(self.diffusion2))
+
+    def forward(
+        self, x: torch.Tensor, t: torch.Tensor, c: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        v_val = self.velocity_model(x, t, c)
+        s_val = self.score_model(x, t, c)
+        gg_val = self.gamma_schedule.gamma_gamma_dot(t)
+        g2_val = self._diffusion2(t)
+        coeff = -gg_val + 0.5 * g2_val
+        coeff = _expand_time_like(coeff, s_val, self.event_ndim)
+        return v_val + coeff * s_val
 
 
 class MirrorVelocityFromScore(nn.Module):

--- a/src/nami/interpolants/transforms.py
+++ b/src/nami/interpolants/transforms.py
@@ -144,6 +144,11 @@ class MarkovizationDriftFromVelocityScore(nn.Module):
     where ``u(x, t) = v(x, t) - gamma(t) * gamma_dot(t) * s(x, t)``.
     Equivalently:
     ``b(x, t) = v(x, t) + (-gamma*gamma_dot + 0.5*g^2) * s(x, t)``.
+
+    ``diffusion2`` is the squared diffusion coefficient ``g(t)^2``, given as a
+    constant ``float`` or a plain callable ``(Tensor) -> Tensor``.  It is **not**
+    registered as an ``nn.Module`` submodule, so learnable diffusion schedules
+    should be managed separately.
     """
 
     def __init__(

--- a/src/nami/losses/__init__.py
+++ b/src/nami/losses/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
+from .bridge import bridge_matching_loss
 from .fm import fm_loss
 from .stochastic_fm import stochastic_fm_loss
 
-__all__ = ["fm_loss", "stochastic_fm_loss"]
+__all__ = ["bridge_matching_loss", "fm_loss", "stochastic_fm_loss"]

--- a/src/nami/losses/bridge.py
+++ b/src/nami/losses/bridge.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import torch
+
+from ..paths.bridge import BrownianBridgePath
+from ._common import (
+    leading_shape,
+    per_sample_mse,
+    prepare_time,
+    reduce_loss,
+    require_event_ndim,
+)
+
+
+def bridge_matching_loss(
+    flow_field,
+    score_field,
+    x_target: torch.Tensor,
+    x_source: torch.Tensor,
+    t: torch.Tensor | None = None,
+    c: torch.Tensor | None = None,
+    *,
+    path: BrownianBridgePath | None = None,
+    z: torch.Tensor | None = None,
+    flow_weight: float = 1.0,
+    score_weight: float = 1.0,
+    reduction: str = "mean",
+) -> torch.Tensor:
+    """Schrodinger bridge matching loss (flow + score regression).
+
+    ``x_target`` should be posterior-side samples (paired with context ``c`` if used),
+    and ``x_source`` should be independent prior-side samples.
+
+    If ``t`` is not provided, times are sampled uniformly on
+    ``[path.eps, 1 - path.eps]`` to avoid endpoint singularities in bridge targets.
+
+    Reference:
+    https://proceedings.mlr.press/v238/tong24a/tong24a.pdf
+    """
+    event_ndim = require_event_ndim(flow_field)
+    score_event_ndim = require_event_ndim(score_field)
+    if event_ndim != score_event_ndim:
+        msg = "flow_field.event_ndim and score_field.event_ndim must match"
+        raise ValueError(msg)
+
+    if path is None:
+        path = BrownianBridgePath()
+
+    lead = leading_shape(x_target, event_ndim)
+    if t is None:
+        dtype = x_target.dtype if x_target.dtype.is_floating_point else torch.float32
+        t = torch.rand(lead, device=x_target.device, dtype=dtype)
+        t = path.eps + (1.0 - 2.0 * path.eps) * t
+    else:
+        t = prepare_time(x_target, lead, t)
+
+    if z is not None and tuple(z.shape) != tuple(x_target.shape):
+        msg = "z must match the shape of x_target"
+        raise ValueError(msg)
+
+    xt = path.sample_xt(x_target, x_source, t, z=z)
+    flow_target = path.target_ut(x_target, x_source, t, xt=xt)
+    score_tgt = path.score_target(x_target, x_source, t, xt=xt)
+
+    vt = flow_field(xt, t, c)
+    st = score_field(xt, t, c)
+
+    flow_mse = per_sample_mse(vt, flow_target, lead)
+    score_mse = per_sample_mse(st, score_tgt, lead)
+    loss = flow_weight * flow_mse + score_weight * score_mse
+    return reduce_loss(loss, reduction)

--- a/src/nami/paths/__init__.py
+++ b/src/nami/paths/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
+from .bridge import BrownianBridgePath
 from .cosine import CosinePath
 from .linear import LinearPath
 
-__all__ = ["CosinePath", "LinearPath"]
+__all__ = ["BrownianBridgePath", "CosinePath", "LinearPath"]

--- a/src/nami/paths/base.py
+++ b/src/nami/paths/base.py
@@ -4,12 +4,44 @@ import torch
 
 
 class ProbabilityPath:
+    """Base class for probability paths that interpolate between target and source.
+
+    Subclasses implement ``sample_xt`` to draw noisy interpolants and
+    ``target_ut`` to return the conditional velocity target used for
+    flow-matching losses.  Stochastic paths (e.g. Brownian bridges) may
+    additionally override ``score_target`` to provide the conditional score.
+
+    Parameters passed as keyword-only arguments (``z``, ``xt``) are optional
+    hooks for deterministic sampling and stochastic correction terms
+    respectively.  Deterministic paths may safely ignore them.
+    """
+
     def sample_xt(
-        self, x_target: torch.Tensor, x_source: torch.Tensor, t: torch.Tensor
+        self,
+        x_target: torch.Tensor,
+        x_source: torch.Tensor,
+        t: torch.Tensor,
+        *,
+        z: torch.Tensor | None = None,
     ) -> torch.Tensor:
         raise NotImplementedError
 
     def target_ut(
-        self, x_target: torch.Tensor, x_source: torch.Tensor, t: torch.Tensor
+        self,
+        x_target: torch.Tensor,
+        x_source: torch.Tensor,
+        t: torch.Tensor,
+        *,
+        xt: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+
+    def score_target(
+        self,
+        x_target: torch.Tensor,
+        x_source: torch.Tensor,
+        t: torch.Tensor,
+        *,
+        xt: torch.Tensor,
     ) -> torch.Tensor:
         raise NotImplementedError

--- a/src/nami/paths/bridge.py
+++ b/src/nami/paths/bridge.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+from .base import ProbabilityPath
+
+
+@dataclass(frozen=True)
+class BrownianBridgePath(ProbabilityPath):
+    """Brownian bridge probability path for Schrodinger bridge matching.
+
+    Interpolates between ``x_target`` (at ``t=0``) and ``x_source`` (at ``t=1``)
+    along a Brownian bridge with diffusion coefficient ``sigma``.
+
+    When reconstructing probability-flow or markovization drift from flow+score
+    models, use a gamma schedule consistent with this path variance and epsilon.
+    ``gamma_schedule()`` provides this mapping.
+    """
+
+    sigma: float = 1.0
+    eps: float = 1e-5
+
+    def __post_init__(self) -> None:
+        if self.sigma <= 0:
+            msg = "sigma must be positive"
+            raise ValueError(msg)
+        if self.eps <= 0:
+            msg = "eps must be positive"
+            raise ValueError(msg)
+        if self.eps >= 0.5:
+            msg = "eps must be < 0.5"
+            raise ValueError(msg)
+
+    def gamma_schedule(self):
+        """Return a gamma schedule consistent with this path's ``sigma`` and ``eps``."""
+        from ..interpolants.gamma import ScaledBrownianGamma
+
+        return ScaledBrownianGamma.from_sigma(self.sigma, eps=self.eps)
+
+    def sample_xt(
+        self,
+        x_target: torch.Tensor,
+        x_source: torch.Tensor,
+        t: torch.Tensor,
+        *,
+        z: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        t = t.reshape(t.shape + (1,) * (x_target.ndim - t.ndim))
+        mu = (1.0 - t) * x_target + t * x_source
+        if z is None:
+            z = torch.randn_like(mu)
+        std = self.sigma * torch.sqrt(t * (1.0 - t))
+        return mu + std * z
+
+    def target_ut(
+        self,
+        x_target: torch.Tensor,
+        x_source: torch.Tensor,
+        t: torch.Tensor,
+        *,
+        xt: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if xt is None:
+            return x_source - x_target
+        t = t.reshape(t.shape + (1,) * (x_target.ndim - t.ndim))
+        mu = (1.0 - t) * x_target + t * x_source
+        denom = 2.0 * torch.clamp(t * (1.0 - t), min=self.eps)
+        coeff = (1.0 - 2.0 * t) / denom
+        return (x_source - x_target) + coeff * (xt - mu)
+
+    def score_target(
+        self,
+        x_target: torch.Tensor,
+        x_source: torch.Tensor,
+        t: torch.Tensor,
+        *,
+        xt: torch.Tensor,
+    ) -> torch.Tensor:
+        t = t.reshape(t.shape + (1,) * (x_target.ndim - t.ndim))
+        mu = (1.0 - t) * x_target + t * x_source
+        var = self.sigma**2 * torch.clamp(t * (1.0 - t), min=self.eps)
+        return (mu - xt) / var

--- a/src/nami/paths/cosine.py
+++ b/src/nami/paths/cosine.py
@@ -9,8 +9,14 @@ from .base import ProbabilityPath
 
 class CosinePath(ProbabilityPath):
     def sample_xt(
-        self, x_target: torch.Tensor, x_source: torch.Tensor, t: torch.Tensor
+        self,
+        x_target: torch.Tensor,
+        x_source: torch.Tensor,
+        t: torch.Tensor,
+        *,
+        z: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        _ = z
         alpha_t = self._alpha(t)
         sigma_t = self._sigma(t)
         alpha_t_reshaped = alpha_t.reshape(
@@ -23,8 +29,14 @@ class CosinePath(ProbabilityPath):
         return alpha_t_reshaped * x_target + sigma_t_reshaped * x_source
 
     def target_ut(
-        self, x_target: torch.Tensor, x_source: torch.Tensor, t: torch.Tensor
+        self,
+        x_target: torch.Tensor,
+        x_source: torch.Tensor,
+        t: torch.Tensor,
+        *,
+        xt: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        _ = xt
         alpha_prime = self._alpha_prime(t)
         sigma_prime = self._sigma_prime(t)
 

--- a/src/nami/paths/linear.py
+++ b/src/nami/paths/linear.py
@@ -7,14 +7,25 @@ from .base import ProbabilityPath
 
 class LinearPath(ProbabilityPath):
     def sample_xt(
-        self, x_target: torch.Tensor, x_source: torch.Tensor, t: torch.Tensor
+        self,
+        x_target: torch.Tensor,
+        x_source: torch.Tensor,
+        t: torch.Tensor,
+        *,
+        z: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        _ = z
         # broadcast t to the same shape as x_target to allow for implicit broadcasting
         t = t.reshape(t.shape + (1,) * (x_target.ndim - t.ndim))
         return (1.0 - t) * x_target + t * x_source
 
     def target_ut(
-        self, x_target: torch.Tensor, x_source: torch.Tensor, t: torch.Tensor
+        self,
+        x_target: torch.Tensor,
+        x_source: torch.Tensor,
+        t: torch.Tensor,
+        *,
+        xt: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        _ = t
+        _ = t, xt
         return x_source - x_target

--- a/tests/interpolants/test_gamma_schedules.py
+++ b/tests/interpolants/test_gamma_schedules.py
@@ -45,3 +45,29 @@ class TestScaledBrownianGamma:
             rtol=1e-6,
             atol=1e-6,
         )
+
+    @pytest.mark.parametrize("sigma", [0.0, -1.0], ids=["zero", "negative"])
+    def test_from_sigma_invalid_raises(self, sigma):
+        with pytest.raises(ValueError, match="sigma must be positive"):
+            ScaledBrownianGamma.from_sigma(sigma=sigma)
+
+    def test_from_sigma_matches_scale_parameterization(self):
+        sigma = 1.7
+        eps = 1e-5
+        t = torch.linspace(0.1, 0.9, 9)
+
+        from_sigma = ScaledBrownianGamma.from_sigma(sigma=sigma, eps=eps)
+        from_scale = ScaledBrownianGamma(scale=sigma**2, eps=eps)
+
+        assert torch.allclose(
+            from_sigma.gamma(t), from_scale.gamma(t), atol=1e-6, rtol=1e-6
+        )
+        assert torch.allclose(
+            from_sigma.gamma_dot(t), from_scale.gamma_dot(t), atol=1e-6, rtol=1e-6
+        )
+        assert torch.allclose(
+            from_sigma.gamma_gamma_dot(t),
+            from_scale.gamma_gamma_dot(t),
+            atol=1e-6,
+            rtol=1e-6,
+        )

--- a/tests/interpolants/test_interpolant_transforms.py
+++ b/tests/interpolants/test_interpolant_transforms.py
@@ -6,9 +6,11 @@ from torch import nn
 from nami.interpolants.gamma import BrownianGamma, ScaledBrownianGamma, ZeroGamma
 from nami.interpolants.transforms import (
     DriftFromVelocityScore,
+    MarkovizationDriftFromVelocityScore,
     MirrorVelocityFromScore,
     ScoreFromNoise,
 )
+from nami.paths.bridge import BrownianBridgePath
 
 
 def _expand_like_time(
@@ -126,8 +128,50 @@ class TestDriftFromVelocityScore:
         out = wrapper(x, t)
 
         gg = _expand_like_time(gamma.gamma_gamma_dot(t), x)
-        expected = torch.full_like(x, 2.0) + gg * 3.0
+        expected = torch.full_like(x, 2.0) - gg * 3.0
         assert torch.allclose(out, expected, rtol=1e-6, atol=1e-6)
+
+    def test_bridge_probability_flow_reconstruction_with_sigma(self):
+        sigma = 1.7
+        path = BrownianBridgePath(sigma=sigma)
+        x_target = torch.randn(8, 3)
+        x_source = torch.randn(8, 3)
+        t = torch.rand(8).clamp(0.05, 0.95)
+        z = torch.randn_like(x_target)
+        xt = path.sample_xt(x_target, x_source, t, z=z)
+
+        flow_target = path.target_ut(x_target, x_source, t, xt=xt)
+        score_target = path.score_target(x_target, x_source, t, xt=xt)
+
+        class TensorField(nn.Module):
+            def __init__(self, value):
+                super().__init__()
+                self.value = value
+
+            @property
+            def event_ndim(self) -> int:
+                return 1
+
+            def forward(self, x, t, c=None):
+                _ = x, t, c
+                return self.value
+
+        gamma = ScaledBrownianGamma(scale=sigma**2)
+        wrapper = DriftFromVelocityScore(
+            TensorField(flow_target),
+            TensorField(score_target),
+            gamma,
+        )
+        out = wrapper(xt, t)
+
+        t_expanded = t.reshape(t.shape + (1,) * (x_target.ndim - t.ndim))
+        mu = (1.0 - t_expanded) * x_target + t_expanded * x_source
+        coeff = (1.0 - 2.0 * t_expanded) / torch.clamp(
+            t_expanded * (1.0 - t_expanded), min=path.eps
+        )
+        expected = (x_source - x_target) + coeff * (xt - mu)
+
+        assert torch.allclose(out, expected, rtol=1e-5, atol=1e-5)
 
 
 class TestMirrorVelocityFromScore:
@@ -145,4 +189,49 @@ class TestMirrorVelocityFromScore:
         expected = gg * 4.0
         assert wrapper.event_ndim == 1
         assert torch.allclose(out, expected, rtol=1e-6, atol=1e-6)
+        assert score.last_c is c
+
+
+class TestMarkovizationDriftFromVelocityScore:
+    def test_formula_with_constant_diffusion2(self):
+        velocity = ConstantModel(2.0)
+        score = ConstantModel(3.0)
+        gamma = ScaledBrownianGamma(scale=1.5)
+        wrapper = MarkovizationDriftFromVelocityScore(
+            velocity,
+            score,
+            gamma,
+            diffusion2=4.0,
+        )
+
+        x = torch.randn(5, 7, 2)
+        t = torch.linspace(0.1, 0.9, 7)
+        out = wrapper(x, t)
+
+        gg = _expand_like_time(gamma.gamma_gamma_dot(t), x)
+        expected = torch.full_like(x, 2.0) + (-gg + 2.0) * 3.0
+        assert torch.allclose(out, expected, rtol=1e-6, atol=1e-6)
+
+    def test_zero_diffusion2_matches_probability_flow(self):
+        velocity = ConstantModel(2.0)
+        score = ConstantModel(3.0)
+        gamma = BrownianGamma()
+        markov = MarkovizationDriftFromVelocityScore(
+            velocity,
+            score,
+            gamma,
+            diffusion2=0.0,
+        )
+        ode = DriftFromVelocityScore(velocity, score, gamma)
+
+        x = torch.randn(4, 6)
+        t = torch.rand(4).clamp(0.1, 0.9)
+        c = torch.randn(4, 1)
+
+        out_markov = markov(x, t, c)
+        out_ode = ode(x, t, c)
+
+        assert markov.event_ndim == 1
+        assert torch.allclose(out_markov, out_ode, rtol=1e-6, atol=1e-6)
+        assert velocity.last_c is c
         assert score.last_c is c

--- a/tests/interpolants/test_interpolant_transforms.py
+++ b/tests/interpolants/test_interpolant_transforms.py
@@ -212,6 +212,27 @@ class TestMarkovizationDriftFromVelocityScore:
         expected = torch.full_like(x, 2.0) + (-gg + 2.0) * 3.0
         assert torch.allclose(out, expected, rtol=1e-6, atol=1e-6)
 
+    def test_formula_with_callable_diffusion2(self):
+        velocity = ConstantModel(2.0)
+        score = ConstantModel(3.0)
+        gamma = ScaledBrownianGamma(scale=1.5)
+        diffusion2_fn = lambda t: 2.0 * t  # noqa: E731
+        wrapper = MarkovizationDriftFromVelocityScore(
+            velocity,
+            score,
+            gamma,
+            diffusion2=diffusion2_fn,
+        )
+
+        x = torch.randn(5, 7, 2)
+        t = torch.linspace(0.1, 0.9, 7)
+        out = wrapper(x, t)
+
+        gg = _expand_like_time(gamma.gamma_gamma_dot(t), x)
+        g2 = _expand_like_time(2.0 * t, x)
+        expected = torch.full_like(x, 2.0) + (-gg + 0.5 * g2) * 3.0
+        assert torch.allclose(out, expected, rtol=1e-6, atol=1e-6)
+
     def test_zero_diffusion2_matches_probability_flow(self):
         velocity = ConstantModel(2.0)
         score = ConstantModel(3.0)

--- a/tests/losses/test_bridge_matching.py
+++ b/tests/losses/test_bridge_matching.py
@@ -61,7 +61,41 @@ class _PerfectScoreField(nn.Module):
         return self.path.score_target(self.x_target, self.x_source, t, xt=xt)
 
 
+class _LinearField(nn.Module):
+    """Minimal learnable field for gradient testing."""
+
+    def __init__(self, dim: int, event_ndim: int = 1):
+        super().__init__()
+        self.linear = nn.Linear(dim, dim, bias=False)
+        self._event_ndim = event_ndim
+
+    @property
+    def event_ndim(self) -> int:
+        return self._event_ndim
+
+    def forward(self, x, t, c=None):
+        _ = t, c
+        return self.linear(x)
+
+
 class TestBridgeMatchingLoss:
+    def test_gradients_flow_to_parameters(self):
+        """Loss should produce gradients for both flow and score model parameters."""
+        torch.manual_seed(0)
+        flow = _LinearField(dim=3)
+        score = _LinearField(dim=3)
+        x_target = torch.randn(4, 3)
+        x_source = torch.randn(4, 3)
+        t = torch.rand(4).clamp(0.05, 0.95)
+
+        loss = bridge_matching_loss(flow, score, x_target, x_source, t=t)
+        loss.backward()
+
+        assert flow.linear.weight.grad is not None
+        assert score.linear.weight.grad is not None
+        assert flow.linear.weight.grad.abs().sum() > 0
+        assert score.linear.weight.grad.abs().sum() > 0
+
     def test_reductions(self):
         torch.manual_seed(0)
         flow = _Field()

--- a/tests/losses/test_bridge_matching.py
+++ b/tests/losses/test_bridge_matching.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+
+from nami.losses.bridge import bridge_matching_loss
+from nami.paths.bridge import BrownianBridgePath
+
+
+class _Field(nn.Module):
+    def __init__(self, event_ndim: int = 1):
+        super().__init__()
+        self._event_ndim = event_ndim
+        self.last_c = None
+        self.last_t = None
+
+    @property
+    def event_ndim(self) -> int:
+        return self._event_ndim
+
+    def forward(self, x, t, c=None):
+        self.last_t = t
+        self.last_c = c
+        return torch.zeros_like(x)
+
+
+class _PerfectFlowField(nn.Module):
+    """Returns exact flow targets (requires path and paired samples)."""
+
+    def __init__(self, path, x_target, x_source):
+        super().__init__()
+        self.path = path
+        self.x_target = x_target
+        self.x_source = x_source
+
+    @property
+    def event_ndim(self) -> int:
+        return 1
+
+    def forward(self, xt, t, c=None):
+        _ = c
+        return self.path.target_ut(self.x_target, self.x_source, t, xt=xt)
+
+
+class _PerfectScoreField(nn.Module):
+    """Returns exact score targets (requires path and paired samples)."""
+
+    def __init__(self, path, x_target, x_source):
+        super().__init__()
+        self.path = path
+        self.x_target = x_target
+        self.x_source = x_source
+
+    @property
+    def event_ndim(self) -> int:
+        return 1
+
+    def forward(self, xt, t, c=None):
+        _ = c
+        return self.path.score_target(self.x_target, self.x_source, t, xt=xt)
+
+
+class TestBridgeMatchingLoss:
+    def test_reductions(self):
+        torch.manual_seed(0)
+        flow = _Field()
+        score = _Field()
+        x_target = torch.randn(5, 3)
+        x_source = torch.randn(5, 3)
+        t = torch.rand(5).clamp(0.05, 0.95)
+        z = torch.randn_like(x_target)
+
+        loss_none = bridge_matching_loss(
+            flow, score, x_target, x_source, t=t, z=z, reduction="none"
+        )
+        loss_sum = bridge_matching_loss(
+            flow, score, x_target, x_source, t=t, z=z, reduction="sum"
+        )
+        loss_mean = bridge_matching_loss(
+            flow, score, x_target, x_source, t=t, z=z, reduction="mean"
+        )
+
+        assert loss_none.shape == (5,)
+        assert loss_sum.shape == ()
+        assert loss_mean.shape == ()
+        assert torch.isclose(loss_sum, loss_none.sum())
+        assert torch.isclose(loss_mean, loss_none.mean())
+
+    def test_invalid_z_shape_raises(self):
+        flow = _Field()
+        score = _Field()
+        x_target = torch.randn(4, 3)
+        x_source = torch.randn(4, 3)
+        t = torch.rand(4)
+        z = torch.randn(4, 2)
+
+        with pytest.raises(ValueError, match="z must match the shape"):
+            bridge_matching_loss(flow, score, x_target, x_source, t=t, z=z)
+
+    def test_event_ndim_mismatch_raises(self):
+        flow = _Field(event_ndim=1)
+        score = _Field(event_ndim=2)
+        x_target = torch.randn(4, 3)
+        x_source = torch.randn(4, 3)
+
+        with pytest.raises(ValueError, match="event_ndim"):
+            bridge_matching_loss(flow, score, x_target, x_source)
+
+    def test_flow_weight_zero(self):
+        """With flow_weight=0, loss depends only on score."""
+        torch.manual_seed(0)
+        flow = _Field()
+        score = _Field()
+        x_target = torch.randn(5, 3)
+        x_source = torch.randn(5, 3)
+        t = torch.rand(5).clamp(0.05, 0.95)
+        z = torch.randn_like(x_target)
+
+        loss_both = bridge_matching_loss(
+            flow,
+            score,
+            x_target,
+            x_source,
+            t=t,
+            z=z,
+            flow_weight=0.0,
+            score_weight=1.0,
+            reduction="none",
+        )
+        # Score-only loss should not depend on flow field output
+        # Since ZeroField returns zeros, score_mse = ||0 - score_target||^2
+        # Changing flow_weight to 0 should remove the flow contribution
+        loss_with_flow = bridge_matching_loss(
+            flow,
+            score,
+            x_target,
+            x_source,
+            t=t,
+            z=z,
+            flow_weight=1.0,
+            score_weight=1.0,
+            reduction="none",
+        )
+        loss_flow_only = bridge_matching_loss(
+            flow,
+            score,
+            x_target,
+            x_source,
+            t=t,
+            z=z,
+            flow_weight=1.0,
+            score_weight=0.0,
+            reduction="none",
+        )
+
+        # loss_both = flow_mse + score_mse
+        # loss_with_flow_zero = score_mse
+        # loss_flow_only = flow_mse
+        assert torch.allclose(loss_with_flow, loss_both + loss_flow_only)
+
+    def test_score_weight_zero(self):
+        """With score_weight=0, loss depends only on flow."""
+        torch.manual_seed(0)
+        flow = _Field()
+        score = _Field()
+        x_target = torch.randn(5, 3)
+        x_source = torch.randn(5, 3)
+        t = torch.rand(5).clamp(0.05, 0.95)
+        z = torch.randn_like(x_target)
+
+        loss_score_zero = bridge_matching_loss(
+            flow,
+            score,
+            x_target,
+            x_source,
+            t=t,
+            z=z,
+            flow_weight=1.0,
+            score_weight=0.0,
+            reduction="none",
+        )
+        loss_flow_zero = bridge_matching_loss(
+            flow,
+            score,
+            x_target,
+            x_source,
+            t=t,
+            z=z,
+            flow_weight=0.0,
+            score_weight=1.0,
+            reduction="none",
+        )
+        loss_both = bridge_matching_loss(
+            flow,
+            score,
+            x_target,
+            x_source,
+            t=t,
+            z=z,
+            flow_weight=1.0,
+            score_weight=1.0,
+            reduction="none",
+        )
+
+        assert torch.allclose(loss_both, loss_score_zero + loss_flow_zero)
+
+    def test_context_forwarding(self):
+        """Context c should be forwarded to both fields."""
+        flow = _Field()
+        score = _Field()
+        x_target = torch.randn(4, 3)
+        x_source = torch.randn(4, 3)
+        t = torch.rand(4).clamp(0.05, 0.95)
+        c = torch.randn(4, 2)
+
+        bridge_matching_loss(flow, score, x_target, x_source, t=t, c=c)
+
+        assert flow.last_c is c
+        assert score.last_c is c
+
+    def test_perfect_fields_zero_loss(self):
+        """Fields returning exact targets should give zero loss."""
+        torch.manual_seed(42)
+        path = BrownianBridgePath(sigma=1.0)
+        x_target = torch.randn(6, 4)
+        x_source = torch.randn(6, 4)
+        t = torch.rand(6).clamp(0.05, 0.95)
+        z = torch.randn_like(x_target)
+
+        flow = _PerfectFlowField(path, x_target, x_source)
+        score = _PerfectScoreField(path, x_target, x_source)
+
+        loss = bridge_matching_loss(
+            flow, score, x_target, x_source, t=t, z=z, path=path
+        )
+
+        assert torch.allclose(loss, torch.tensor(0.0), atol=1e-10)
+
+    def test_deterministic_with_fixed_z_and_t(self):
+        """Fixed z and t give deterministic loss values."""
+        flow = _Field()
+        score = _Field()
+        x_target = torch.randn(4, 3)
+        x_source = torch.randn(4, 3)
+        t = torch.tensor([0.25, 0.5, 0.5, 0.75])
+        z = torch.randn_like(x_target)
+
+        loss1 = bridge_matching_loss(flow, score, x_target, x_source, t=t, z=z)
+        loss2 = bridge_matching_loss(flow, score, x_target, x_source, t=t, z=z)
+
+        assert torch.allclose(loss1, loss2)
+
+    def test_samples_t_within_path_eps_when_t_is_none(self):
+        flow = _Field()
+        score = _Field()
+        path = BrownianBridgePath(eps=0.2)
+        x_target = torch.randn(16, 3)
+        x_source = torch.randn(16, 3)
+
+        _ = bridge_matching_loss(flow, score, x_target, x_source, path=path)
+
+        assert flow.last_t is not None
+        assert score.last_t is not None
+        assert torch.all(flow.last_t >= path.eps)
+        assert torch.all(flow.last_t <= 1.0 - path.eps)
+        assert torch.all(score.last_t >= path.eps)
+        assert torch.all(score.last_t <= 1.0 - path.eps)

--- a/tests/paths/test_base_path.py
+++ b/tests/paths/test_base_path.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from nami.paths.base import ProbabilityPath
+
+
+class TestProbabilityPathInterface:
+    def setup_method(self):
+        self.path = ProbabilityPath()
+        self.x = torch.randn(2, 3)
+        self.t = torch.rand(2)
+
+    def test_sample_xt_raises(self):
+        with pytest.raises(NotImplementedError):
+            self.path.sample_xt(self.x, self.x, self.t)
+
+    def test_target_ut_raises(self):
+        with pytest.raises(NotImplementedError):
+            self.path.target_ut(self.x, self.x, self.t)
+
+    def test_score_target_raises(self):
+        with pytest.raises(NotImplementedError):
+            self.path.score_target(self.x, self.x, self.t, xt=self.x)

--- a/tests/paths/test_bridge_path.py
+++ b/tests/paths/test_bridge_path.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from nami.paths.bridge import BrownianBridgePath
+
+
+class TestBrownianBridgeValidation:
+    def test_non_positive_sigma_raises(self):
+        with pytest.raises(ValueError, match="sigma must be positive"):
+            BrownianBridgePath(sigma=0.0)
+
+        with pytest.raises(ValueError, match="sigma must be positive"):
+            BrownianBridgePath(sigma=-1.0)
+
+    def test_non_positive_eps_raises(self):
+        with pytest.raises(ValueError, match="eps must be positive"):
+            BrownianBridgePath(eps=0.0)
+
+        with pytest.raises(ValueError, match="eps must be positive"):
+            BrownianBridgePath(eps=-1e-6)
+
+    @pytest.mark.parametrize("eps", [0.5, 0.9], ids=["half", "large"])
+    def test_large_eps_raises(self, eps):
+        with pytest.raises(ValueError, match="eps must be < 0.5"):
+            BrownianBridgePath(eps=eps)
+
+
+class TestBrownianBridgeSampleXt:
+    """Tests for BrownianBridgePath.sample_xt method."""
+
+    def test_t0_returns_target(self):
+        """At t=0, xt should equal x_target (with z=0)."""
+        path = BrownianBridgePath()
+        x_target = torch.randn(4, 3)
+        x_source = torch.randn(4, 3)
+        t = torch.zeros(4)
+        z = torch.zeros_like(x_target)
+
+        xt = path.sample_xt(x_target, x_source, t, z=z)
+
+        assert torch.allclose(xt, x_target)
+
+    def test_t1_returns_source(self):
+        """At t=1, xt should equal x_source (with z=0)."""
+        path = BrownianBridgePath()
+        x_target = torch.randn(4, 3)
+        x_source = torch.randn(4, 3)
+        t = torch.ones(4)
+        z = torch.zeros_like(x_target)
+
+        xt = path.sample_xt(x_target, x_source, t, z=z)
+
+        assert torch.allclose(xt, x_source)
+
+    def test_midpoint_mean(self):
+        """At t=0.5, mean should be the midpoint of x_target and x_source."""
+        path = BrownianBridgePath()
+        x_target = torch.ones(4, 3)
+        x_source = torch.zeros(4, 3)
+        t = torch.full((4,), 0.5)
+        z = torch.zeros_like(x_target)
+
+        xt = path.sample_xt(x_target, x_source, t, z=z)
+
+        expected = 0.5 * x_target + 0.5 * x_source
+        assert torch.allclose(xt, expected)
+
+    def test_midpoint_std(self):
+        """At t=0.5, std should be sigma/2."""
+        path = BrownianBridgePath(sigma=1.0)
+        x_target = torch.zeros(4, 3)
+        x_source = torch.zeros(4, 3)
+        t = torch.full((4,), 0.5)
+        z = torch.ones_like(x_target)
+
+        xt = path.sample_xt(x_target, x_source, t, z=z)
+
+        # std = sigma * sqrt(0.5 * 0.5) = sigma * 0.5
+        expected = 0.5 * z
+        assert torch.allclose(xt, expected)
+
+    def test_deterministic_with_fixed_z(self):
+        """Fixed z gives reproducible results."""
+        path = BrownianBridgePath()
+        x_target = torch.randn(4, 3)
+        x_source = torch.randn(4, 3)
+        t = torch.rand(4)
+        z = torch.randn_like(x_target)
+
+        xt1 = path.sample_xt(x_target, x_source, t, z=z)
+        xt2 = path.sample_xt(x_target, x_source, t, z=z)
+
+        assert torch.allclose(xt1, xt2)
+
+    def test_broadcasting(self):
+        """Time tensor should broadcast correctly over batch dimensions."""
+        path = BrownianBridgePath()
+        x_target = torch.randn(2, 3, 4)
+        x_source = torch.randn(2, 3, 4)
+        t = torch.tensor([0.0, 1.0])
+        z = torch.zeros_like(x_target)
+
+        xt = path.sample_xt(x_target, x_source, t, z=z)
+
+        assert xt.shape == x_target.shape
+        assert torch.allclose(xt[0], x_target[0])
+        assert torch.allclose(xt[1], x_source[1])
+
+
+class TestBrownianBridgeTargetUt:
+    """Tests for BrownianBridgePath.target_ut method."""
+
+    def test_without_xt_returns_linear(self):
+        """Without xt, target_ut returns x_source - x_target (same as LinearPath)."""
+        path = BrownianBridgePath()
+        x_target = torch.randn(4, 3)
+        x_source = torch.randn(4, 3)
+        t = torch.rand(4)
+
+        ut = path.target_ut(x_target, x_source, t)
+
+        assert torch.allclose(ut, x_source - x_target)
+
+    def test_with_xt_at_mean_correction_vanishes(self):
+        """When xt equals the mean, the stochastic correction vanishes."""
+        path = BrownianBridgePath()
+        x_target = torch.randn(4, 3)
+        x_source = torch.randn(4, 3)
+        t = torch.rand(4).clamp(0.05, 0.95)  # avoid boundary
+
+        t_expanded = t.reshape(t.shape + (1,) * (x_target.ndim - t.ndim))
+        mu = (1.0 - t_expanded) * x_target + t_expanded * x_source
+        ut = path.target_ut(x_target, x_source, t, xt=mu)
+
+        expected = x_source - x_target
+        assert torch.allclose(ut, expected, atol=1e-5)
+
+    def test_known_values_t025(self):
+        """Hand-computed values at t=0.25 with fixed z."""
+        path = BrownianBridgePath(sigma=1.0)
+        x_target = torch.tensor([[1.0]])
+        x_source = torch.tensor([[0.0]])
+        t = torch.tensor([0.25])
+        z = torch.tensor([[1.0]])
+
+        xt = path.sample_xt(x_target, x_source, t, z=z)
+        ut = path.target_ut(x_target, x_source, t, xt=xt)
+
+        # mu = 0.75, std = sqrt(0.25*0.75) = sqrt(3)/4
+        # xt = 0.75 + sqrt(3)/4
+        # coeff = (1-0.5)/(2*0.25*0.75) = 0.5/0.375 = 4/3
+        # ut = (0-1) + (4/3)*sqrt(3)/4 = -1 + sqrt(3)/3
+        expected = -1.0 + math.sqrt(3) / 3.0
+        assert torch.allclose(ut, torch.tensor([[expected]]), atol=1e-5)
+
+
+class TestBrownianBridgeScoreTarget:
+    """Tests for BrownianBridgePath.score_target method."""
+
+    def test_at_mean_returns_zero(self):
+        """When xt equals the mean, score is zero."""
+        path = BrownianBridgePath()
+        x_target = torch.randn(4, 3)
+        x_source = torch.randn(4, 3)
+        t = torch.rand(4).clamp(0.05, 0.95)
+
+        t_expanded = t.reshape(t.shape + (1,) * (x_target.ndim - t.ndim))
+        mu = (1.0 - t_expanded) * x_target + t_expanded * x_source
+        score = path.score_target(x_target, x_source, t, xt=mu)
+
+        assert torch.allclose(score, torch.zeros_like(score), atol=1e-5)
+
+    def test_sign_points_toward_mean(self):
+        """Score should point from xt toward mu."""
+        path = BrownianBridgePath()
+        x_target = torch.zeros(4, 3)
+        x_source = torch.zeros(4, 3)
+        t = torch.full((4,), 0.5)
+        # xt above zero -> score should be negative (pointing toward mu=0)
+        xt = torch.ones(4, 3)
+
+        score = path.score_target(x_target, x_source, t, xt=xt)
+
+        assert (score < 0).all()
+
+    def test_scales_with_sigma(self):
+        """Doubling sigma should quarter the score magnitude."""
+        path1 = BrownianBridgePath(sigma=1.0)
+        path2 = BrownianBridgePath(sigma=2.0)
+        x_target = torch.randn(4, 3)
+        x_source = torch.randn(4, 3)
+        t = torch.rand(4).clamp(0.05, 0.95)
+
+        t_expanded = t.reshape(t.shape + (1,) * (x_target.ndim - t.ndim))
+        mu = (1.0 - t_expanded) * x_target + t_expanded * x_source
+        xt = mu + torch.randn_like(mu)
+
+        score1 = path1.score_target(x_target, x_source, t, xt=xt)
+        score2 = path2.score_target(x_target, x_source, t, xt=xt)
+
+        assert torch.allclose(score2, score1 / 4.0, atol=1e-5)
+
+
+class TestBrownianBridgeGammaSchedule:
+    def test_gamma_schedule_matches_sigma_and_eps(self):
+        sigma = 1.7
+        eps = 1e-4
+        path = BrownianBridgePath(sigma=sigma, eps=eps)
+        schedule = path.gamma_schedule()
+        t = torch.linspace(0.1, 0.9, 9)
+
+        assert schedule.scale == pytest.approx(sigma**2)
+        assert schedule.eps == pytest.approx(eps)
+
+        expected_gg = 0.5 * (sigma**2) * (1.0 - 2.0 * t)
+        assert torch.allclose(
+            schedule.gamma_gamma_dot(t), expected_gg, atol=1e-6, rtol=1e-6
+        )


### PR DESCRIPTION
### Description

This MR implements some different parameterisation transformations and a first implementation of some bridge-matching. See [Tong et al. 2024](https://proceedings.mlr.press/v238/tong24a.html) for the SF2M method details.

   - Add `BrownianBridgePath` for Schrodinger bridge matching with flow and score targets
   - Add `bridge_matching_loss` (joint flow + score regression with configurable weights)
   - Add `MarkovizationDriftFromVelocityScore` for SDE drift reconstruction
   - Add `ScaledBrownianGamma.from_sigma` convenience constructor
   - Fix sign in `DriftFromVelocityScore`: `v + gg*s` → `v - gg*s` ( breaking change to current API.)
      - [x] Need to double-check the above.

   - Extend `ProbabilityPath` base class with optional `z`/`xt` kwargs and added a doc string.