### PR TITLE
fix(divergence): add create_graph support and fix retain_graph in div…

### DIFF
--- a/src/nami/divergence/exact.py
+++ b/src/nami/divergence/exact.py
@@ -7,8 +7,9 @@ from .base import DivergenceEstimator
 
 
 class ExactDivergence(DivergenceEstimator):
-    def __init__(self, max_dim: int = 16):
+    def __init__(self, max_dim: int = 16, *, create_graph: bool = False):
         self.max_dim = int(max_dim)
+        self.create_graph = bool(create_graph)
 
     def __call__(
         self, field, x: torch.Tensor, t: torch.Tensor, c: torch.Tensor | None
@@ -34,7 +35,13 @@ class ExactDivergence(DivergenceEstimator):
 
             for i in range(numel):
                 grad = torch.autograd.grad(
-                    v_flat[..., i].sum(), x_req, create_graph=False
+                    v_flat[..., i].sum(),
+                    x_req,
+                    create_graph=self.create_graph,
+                    # When create_graph=True we must retain the graph on every
+                    # component pull, otherwise downstream backward through
+                    # log_prob can fail with "backward through graph a second time".
+                    retain_graph=(self.create_graph or i < numel - 1),
                 )[0]
                 grad_flat = grad.reshape(*lead, numel)
                 div = div + grad_flat[..., i]

--- a/src/nami/divergence/hutchinson.py
+++ b/src/nami/divergence/hutchinson.py
@@ -11,11 +11,12 @@ def _rademacher_like(x: torch.Tensor) -> torch.Tensor:
 
 
 class HutchinsonDivergence(DivergenceEstimator):
-    def __init__(self, probe: str = "rademacher"):
+    def __init__(self, probe: str = "rademacher", *, create_graph: bool = False):
         if probe not in {"rademacher", "gaussian"}:
             msg = "probe must be 'rademacher' or 'gaussian'"
             raise ValueError(msg)
         self.probe = probe
+        self.create_graph = bool(create_graph)
 
     def __call__(
         self, field, x: torch.Tensor, t: torch.Tensor, c: torch.Tensor | None
@@ -39,6 +40,10 @@ class HutchinsonDivergence(DivergenceEstimator):
                 eps = _rademacher_like(x_req)
 
             dot = (v * eps).sum()
-            grad = torch.autograd.grad(dot, x_req, create_graph=False)[0]
+            grad = torch.autograd.grad(
+                dot,
+                x_req,
+                create_graph=self.create_graph,
+            )[0]
 
         return (grad * eps).reshape(*lead, -1).sum(dim=-1)

--- a/tests/divergence/test_create_graph.py
+++ b/tests/divergence/test_create_graph.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from nami.distributions.normal import StandardNormal
+from nami.divergence.exact import ExactDivergence
+from nami.divergence.hutchinson import HutchinsonDivergence
+from nami.processes.fm import FlowMatching
+
+
+class LinearScaleField(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.event_ndim = 1
+        self.scale = nn.Parameter(torch.tensor(1.5))
+        self.dim = int(dim)
+
+    def forward(self, x, t, c=None):
+        _ = t, c
+        return self.scale * x
+
+
+class SingleStepAugmentedSolver:
+    is_sde = False
+    requires_steps = False
+    supports_rsample = True
+
+    def integrate(self, f, x0: torch.Tensor, *, t0: float, t1: float, **kwargs):
+        _ = kwargs
+        return x0 + (t1 - t0) * f(x0, t0)
+
+    def integrate_augmented(
+        self,
+        f_aug,
+        x0: torch.Tensor,
+        logp0: torch.Tensor,
+        *,
+        t0: float,
+        t1: float,
+        **kwargs,
+    ):
+        _ = kwargs
+        _v, logp_dot = f_aug(x0, t0)
+        return x0, logp0 + (t1 - t0) * logp_dot
+
+
+def test_hutchinson_create_graph_controls_param_grad_connectivity():
+    field = LinearScaleField(dim=3)
+    x = torch.randn(5, 3)
+    t = torch.zeros(5)
+
+    div_no_graph = HutchinsonDivergence()(field, x, t, None)
+    assert not div_no_graph.requires_grad
+
+    div_graph = HutchinsonDivergence(create_graph=True)(field, x, t, None)
+    assert div_graph.requires_grad
+
+    div_graph.sum().backward()
+    assert field.scale.grad is not None
+    expected = torch.tensor(float(x.shape[0] * x.shape[1]))
+    assert torch.allclose(field.scale.grad, expected)
+
+
+def test_exact_create_graph_controls_param_grad_connectivity():
+    field = LinearScaleField(dim=4)
+    x = torch.randn(6, 4)
+    t = torch.zeros(6)
+
+    div_no_graph = ExactDivergence(max_dim=16)(field, x, t, None)
+    assert not div_no_graph.requires_grad
+
+    div_graph = ExactDivergence(max_dim=16, create_graph=True)(field, x, t, None)
+    assert div_graph.requires_grad
+
+    div_graph.sum().backward()
+    assert field.scale.grad is not None
+    expected = torch.tensor(float(x.shape[0] * x.shape[1]))
+    assert torch.allclose(field.scale.grad, expected)
+
+
+def test_log_prob_is_differentiable_with_create_graph_estimator():
+    field = LinearScaleField(dim=2)
+    process = FlowMatching(
+        field,
+        StandardNormal(event_shape=(2,)),
+        SingleStepAugmentedSolver(),
+    )()
+    x = torch.zeros(4, 2)
+    estimator = HutchinsonDivergence(create_graph=True)
+
+    loss = -process.log_prob(x, estimator=estimator).sum()
+    loss.backward()
+
+    assert field.scale.grad is not None
+    assert torch.isfinite(field.scale.grad)
+
+
+def test_log_prob_is_differentiable_with_exact_create_graph_estimator():
+    field = LinearScaleField(dim=2)
+    process = FlowMatching(
+        field,
+        StandardNormal(event_shape=(2,)),
+        SingleStepAugmentedSolver(),
+    )()
+    x = torch.zeros(4, 2)
+    estimator = ExactDivergence(max_dim=8, create_graph=True)
+
+    loss = -process.log_prob(x, estimator=estimator).sum()
+    loss.backward()
+
+    assert field.scale.grad is not None
+    assert torch.isfinite(field.scale.grad)


### PR DESCRIPTION
### Description

This PR introduces support for controlling gradient graph connectivity in the divergence estimators, allowing downstream computations (such as `log_prob`) to be differentiable with respect to model parameters. The changes add a `create_graph` option to both `ExactDivergence` and `HutchinsonDivergence` classes, update their gradient computations accordingly, and provides tests to verify correct behaviour.

------