### PR TITLE
fix: make missing divergence estimator exception more explicit

### DIFF
--- a/src/nami/diagnostics.py
+++ b/src/nami/diagnostics.py
@@ -48,11 +48,21 @@ def divergence_stats(
     if estimator is not None:
         div = estimator(field, x, t, c)
     else:
+        call_and_divergence = getattr(field, "call_and_divergence", None)
+        if call_and_divergence is None:
+            msg = (
+                "divergence_stats requires either `estimator=...` or a field "
+                "implementing `call_and_divergence(x, t, c)`"
+            )
+            raise TypeError(msg)
         try:
-            _, div = field.call_and_divergence(x, t, c)
-        except NotImplementedError as exc:
-            msg = "field must implement call_and_divergence or provide an estimator"
-            raise NotImplementedError(msg) from exc
+            _, div = call_and_divergence(x, t, c)
+        except NotImplementedError:
+            msg = (
+                "divergence_stats requires either `estimator=...` or a field "
+                "implementing `call_and_divergence(x, t, c)`"
+            )
+            raise TypeError(msg) from None
 
     return {
         "mean": div.mean(),

--- a/src/nami/processes/fm.py
+++ b/src/nami/processes/fm.py
@@ -184,6 +184,14 @@ class FlowMatchingProcess:
         return self._integrate(f, z, t0=self._t0, t1=self._t1)
 
     def log_prob(self, x: torch.Tensor, *, estimator=None) -> torch.Tensor:
+        """Evaluate log-density via change of variables.
+
+        Callers should usually pass ``estimator=...`` unless the field
+        implements ``call_and_divergence`` itself. We do not auto-select a
+        divergence estimator here because the tradeoff is model-dependent:
+        exact traces are deterministic but can be expensive, while
+        Hutchinson-style estimators scale better but add stochasticity.
+        """
         event_ndim = getattr(self._field, "event_ndim", None)
         if event_ndim is None:
             msg = "field.event_ndim is required"
@@ -198,11 +206,21 @@ class FlowMatchingProcess:
                 v = self._field(xi, tt, context)
                 div = estimator(self._field, xi, tt, context)
             else:
+                call_and_divergence = getattr(self._field, "call_and_divergence", None)
+                if call_and_divergence is None:
+                    msg = (
+                        "log_prob requires either `estimator=...` or a field "
+                        "implementing `call_and_divergence(x, t, c)`"
+                    )
+                    raise TypeError(msg)
                 try:
-                    v, div = self._field.call_and_divergence(xi, tt, context)
-                except NotImplementedError as exc:
-                    msg = "field must implement call_and_divergence or provide an estimator"
-                    raise NotImplementedError(msg) from exc
+                    v, div = call_and_divergence(xi, tt, context)
+                except NotImplementedError:
+                    msg = (
+                        "log_prob requires either `estimator=...` or a field "
+                        "implementing `call_and_divergence(x, t, c)`"
+                    )
+                    raise TypeError(msg) from None
             return v, -div
 
         z, delta = self._integrate_augmented(f_aug, x, logp0, t0=self._t1, t1=self._t0)

--- a/tests/test_flow_matching.py
+++ b/tests/test_flow_matching.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+
+from nami import ExactDivergence, FlowMatching, RK4, StandardNormal
+from nami.fields.base import VectorField
+
+
+class PlainField(nn.Module):
+    event_ndim = 1
+
+    def forward(self, x, t, c=None):
+        _ = t
+        if c is None:
+            return torch.zeros_like(x)
+        return (x * 0) + c.expand_as(x)
+
+
+class BaseVectorField(VectorField):
+    @property
+    def event_ndim(self):
+        return 1
+
+    def forward(self, x, t, c=None):
+        _ = t, c
+        return x
+
+
+def test_log_prob_without_divergence_path_raises_clean_error():
+    process = FlowMatching(
+        PlainField(),
+        StandardNormal(event_shape=(2,)),
+        RK4(steps=2),
+    )()
+    x = torch.zeros(4, 2)
+
+    with pytest.raises(
+        TypeError,
+        match=r"log_prob requires either `estimator=\.\.\.` or a field implementing "
+        r"`call_and_divergence\(x, t, c\)`",
+    ):
+        process.log_prob(x)
+
+
+def test_log_prob_hides_internal_not_implemented_cause():
+    process = FlowMatching(
+        BaseVectorField(),
+        StandardNormal(event_shape=(2,)),
+        RK4(steps=2),
+    )()
+    x = torch.zeros(4, 2)
+
+    with pytest.raises(
+        TypeError,
+        match=r"log_prob requires either `estimator=\.\.\.` or a field implementing "
+        r"`call_and_divergence\(x, t, c\)`",
+    ) as excinfo:
+        process.log_prob(x)
+
+    assert excinfo.value.__cause__ is None
+
+
+def test_conditional_log_prob_supports_plain_module_with_estimator():
+    context = torch.randn(5, 1)
+    process = FlowMatching(
+        PlainField(),
+        StandardNormal(event_shape=(2,)),
+        RK4(steps=2),
+    )(context)
+    x = torch.zeros(5, 2)
+
+    log_prob = process.log_prob(x, estimator=ExactDivergence(max_dim=8))
+
+    assert log_prob.shape == (5,)
+    assert torch.isfinite(log_prob).all()


### PR DESCRIPTION
### Description

This MR updates the user-facing error message when calling the `log_prob()` method without a divergence estimator. I've set this as a `TypeError`, since I guess its a case of the object not respecting the required protocol for the operation, but its somewhat of a stretch and could not think of a better error type without creating a dedicated exception.



~~- [ ] Create a dedicated exception for this instead? e.g. `MissingDivergenceError()`~~

I will add dedicated exception errors in a follow-up PR after some more thoughts.