### PR TITLE
fix: update documentation and examples

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Levi Evans, The NEEDLE Collaboration
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ Guidelines for contributing will soon be added once the project is more stable. 
 
 ---
 
-This project is supported by HelmholtzAI and DESY as part of the [NEEDLE project](https://needle-sbi.github.io/), funded by HelmholtzAI under grant number XXX (TODO: add grant number).
+This project is supported by HelmholtzAI and DESY as part of the [NEEDLE project](https://needle-sbi.github.io/), funded under grant number XXX (TODO: add grant number).
 
 <img src="/docs/_static/institutes/Helmholtz-Logo-Blue-RGB.png" alt="HelmholtzAI" width="160"/> &nbsp;

--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ Guidelines for contributing will soon be added once the project is more stable. 
 
 ---
 
-This project is supported by HelmholtzAI and DESY.
+This project is supported by HelmholtzAI and DESY as part of the [NEEDLE project](https://needle-sbi.github.io/), funded by HelmholtzAI under grant number XXX (TODO: add grant number).
 
 <img src="/docs/_static/institutes/Helmholtz-Logo-Blue-RGB.png" alt="HelmholtzAI" width="160"/> &nbsp;

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Nami is a library for flow-style generative models, with a focus on composable transport-map workflows and SBI applications.
 
-The full guide, examples, tutorials, and API reference live in the [documentation](https://levisamuelevans.github.io/nami/).
+See the [documentation](https://levisamuelevans.github.io/nami/) for a full guide, examples, tutorials, and API reference.
 
 ## Quick Start
 

--- a/books/experiment/generators/index.rst
+++ b/books/experiment/generators/index.rst
@@ -8,4 +8,4 @@ Notebooks exploring generator matching and Itô-operator sampling.
 
    a_simple_generator
    conditional-generator-matching
-   cgm-inpainting
+   inpainting

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -142,14 +142,14 @@ interpolant parameterisations, and SDE drift :math:`f`.
 
    * - Component
      - Definition
-   * - :class:`~nami.ScoreFromEta`
-     - :math:`\nabla \log p_t(x) = \eta_\theta(x, t) / \gamma(t)` for an interpolant parameterisation with :math:`\eta_\theta = \gamma(t)\,\nabla \log p_t`.
-   * - :class:`~nami.ScoreFromRawNoise`
-     - :math:`\nabla \log p_t(x) = -z_\theta(x, t) / \gamma(t)` when the model predicts the raw additive Gaussian noise in :math:`X_t = I_t + \gamma(t)\,z`.
+   * - :func:`~nami.diffusion.eps_to_score` / :func:`~nami.diffusion.score_to_eps`
+     - :math:`\nabla \log p_t(x) = -\varepsilon_\theta(x, t) / \sigma(t)` and its inverse.
+   * - :func:`~nami.diffusion.score_to_x0` / :func:`~nami.diffusion.x0_to_score`
+     - Convert between a score and a clean-sample (:math:`x_0`) prediction given :math:`\alpha(t), \sigma(t)`.
    * - :class:`~nami.DriftFromVelocityScore`
      - :math:`f_t(x) = v_t(x) - \gamma(t)\gamma'(t)\nabla \log p_t(x)`.
-   * - :class:`~nami.MirrorVelocityFromScore`
-     - :math:`m_t(x) = \gamma(t)\gamma'(t)\nabla\log p_t(x)`. Mirror correction term used in backward-SDE formulas.
+   * - :class:`~nami.MarkovizationDriftFromVelocityScore`
+     - Markovised probability-flow drift from separate velocity and score heads.
 
 .. note::
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -111,8 +111,8 @@ Generator matching
 
     process = nami.GeneratorMatching(
         field,
-        operator,
         nami.EulerMaruyama(steps=64),
+        parameterization=nami.generator_prediction(operator),
         event_shape=(2,),
     )
     samples = process(context).sample((128,))
@@ -194,31 +194,26 @@ the SDE. Both halves live in nami: ``regression_loss`` trains the
 Parameterisation transforms
 ----------------------------
 
-Convert between interpolant score-related parameterisations, velocity, and
-drift representations. These are useful when you have a model trained with
-one interpolant parameterisation but need another for sampling.
+Convert between diffusion parameterisations and combine velocity and score
+heads into a drift. These are useful when you have a model trained with one
+parameterisation but need another for sampling.
 
 .. code-block:: python
 
    import nami
 
-   # If the model predicts eta = gamma(t) * score(x, t)
-   score = nami.ScoreFromEta(eta_model, nami.BrownianGamma())
-
-   # If the model predicts the raw Gaussian noise z in x_t = I_t + gamma(t) z
-   score_from_noise = nami.ScoreFromRawNoise(noise_model, nami.BrownianGamma())
+   # Diffusion conversions between eps, score, and x0 (pure tensor functions)
+   score = nami.diffusion.eps_to_score(eps, sigma)
+   eps   = nami.diffusion.score_to_eps(score, sigma)
+   x0    = nami.diffusion.score_to_x0(x, score, sigma, alpha)
 
    # Combine velocity + score into an SDE drift
-   drift = nami.DriftFromVelocityScore(v_model, score, nami.BrownianGamma())
-
-   # Construct the mirror correction term used in backward-SDE formulas
-   mirror_v = nami.MirrorVelocityFromScore(score, nami.BrownianGamma())
+   drift = nami.DriftFromVelocityScore(v_model, score_model, nami.BrownianGamma())
 
 .. note::
 
    For diffusion :math:`\varepsilon`-prediction, use
    :class:`~nami.Diffusion` with
-   ``parameterization=nami.epsilon_prediction(schedule=schedule)``
-   rather than these interpolant wrappers. Diffusion uses :math:`-\varepsilon/\sigma`,
-   while ``ScoreFromEta`` and ``ScoreFromRawNoise`` use interpolant-specific
-   :math:`\gamma(t)`.
+   ``parameterization=nami.epsilon_prediction(schedule=schedule)``, which
+   applies :math:`-\varepsilon/\sigma` internally — you rarely need to
+   convert by hand.

--- a/docs/how-to/bridge-matching.rst
+++ b/docs/how-to/bridge-matching.rst
@@ -9,9 +9,11 @@ This follows the bridge-matching approach of Tong et al.
 
    import nami
 
-   loss = nami.bridge_matching_loss(
-       flow_field, score_field,
-       x_noise=x_noise, x_data=x_data,
+   loss = nami.losses.bridge_matching_loss(
+       flow_field, 
+       score_field,
+       x_noise=x_noise, 
+       x_data=x_data,
        interpolant=nami.BrownianBridgeInterpolant(),
    )
    loss.backward()
@@ -19,7 +21,5 @@ This follows the bridge-matching approach of Tong et al.
 After training, reconstruct the SDE drift from the two fields and sample
 with a standard :class:`~nami.FlowMatching` or :class:`~nami.Diffusion`
 process. The reconstruction uses
-:class:`~nami.DriftFromVelocityScore`; related helpers
-(:class:`~nami.ScoreFromEta`, :class:`~nami.ScoreFromRawNoise`) cover the
-case where the score field is parameterised through an interpolant
-quantity rather than predicted directly.
+:class:`~nami.DriftFromVelocityScore`, which combines the velocity and
+score heads into the probability-flow / SDE drift.

--- a/docs/how-to/convert-parameterizations.rst
+++ b/docs/how-to/convert-parameterizations.rst
@@ -2,30 +2,30 @@ Convert between parameterisations
 =================================
 
 When you have a model trained under one parameterisation but need another
-for sampling, nami provides a small family of transforms that compose with
-the field at sampling time.
+for sampling, nami provides functional conversions that map between the
+diffusion quantities :math:`\varepsilon`, score, and :math:`x_0`, plus
+composite fields that combine a velocity and a score into an SDE drift.
 
 .. code-block:: python
 
    import nami
 
+   # diffusion conversions are pure tensor functions keyed by the schedule
+   # coefficients sigma(t) (and alpha(t) where needed).
+   score = nami.diffusion.eps_to_score(eps, sigma)            # eps(x,t) -> score(x,t)
+   eps   = nami.diffusion.score_to_eps(score, sigma)          # score(x,t) -> eps(x,t)
+   x0    = nami.diffusion.score_to_x0(x, score, sigma, alpha) # score(x,t) -> x0(x,t)
+   score = nami.diffusion.x0_to_score(x, x0, sigma, alpha)    # x0(x,t) -> score(x,t)
+
+   # combine separately trained velocity and score heads into a
+   # probability-flow / SDE drift: u(x,t) = v(x,t) gamma(t) gamma_dot(t) s(x,t)
    gamma = nami.BrownianGamma()
+   drift = nami.DriftFromVelocityScore(v_model, score_model, gamma)
 
-   # Model predicts eta = gamma(t) * score(x, t)
-   score = nami.ScoreFromEta(eta_model, gamma)
-
-   # Model predicts the raw Gaussian noise z in X_t = I_t + gamma(t) z
-   score_from_noise = nami.ScoreFromRawNoise(noise_model, gamma)
-
-   # Combine a velocity and a score into an SDE drift
-   drift = nami.DriftFromVelocityScore(v_model, score, gamma)
-
-   # Mirror correction term used in backward-SDE formulas
-   mirror_v = nami.MirrorVelocityFromScore(score, gamma)
-
-These wrappers are for stochastic-interpolant style parameterisations and
-are not the same as diffusion :math:`\varepsilon`-prediction. For diffusion
-models, the analogous conversion
-:math:`\nabla \log p_t(x) = -\varepsilon_\theta / \sigma(t)` is handled
+For diffusion models the same relation
+:math:`\nabla \log p_t(x) = -\varepsilon_\theta / \sigma(t)` is applied
 internally by :class:`~nami.Diffusion` when you pass
-``parameterization=nami.epsilon_prediction(schedule=schedule)``.
+``parameterization=nami.epsilon_prediction(schedule=schedule)``, so you do
+not normally need to convert by hand. To train or sample directly in the
+score parameterisation, use
+``parameterization=nami.score_prediction(schedule=schedule)``.

--- a/docs/how-to/train-consistency-flow-matching.rst
+++ b/docs/how-to/train-consistency-flow-matching.rst
@@ -10,7 +10,7 @@ recipe. In local nami experiments, consistency training is best treated as
 an experimental one-step approximation layer on top of a strong flow-matching
 baseline. The original paper (Yang et al., 2024) trains from scratch with
 EMA targets and additional schedule details that nami does not currently
-ship.
+include.
 
 .. code-block:: python
 
@@ -68,7 +68,7 @@ To get one-step log-densities, add a log-prob head:
 
 .. code-block:: python
 
-   h_head = nami.ConsistencyHead(dim=dim)
+   h_head = nami.LogDensityHead(dim=dim)
    loss_h = nami.log_density_consistency_loss(
        field, h_head,
        x_noise=x_noise, x_data=x_data,

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -260,7 +260,7 @@ forward pass.
    import torch, nami
 
    field = nami.VelocityField(dim=8)
-   h_head = nami.ConsistencyHead(dim=8, hidden=128, layers=2)
+   h_head = nami.LogDensityHead(dim=8, hidden=128, layers=2)
    x_data = torch.randn(32, 8)
    x_noise = torch.randn_like(x_data)
 
@@ -570,8 +570,9 @@ lazy process. The operator's ``runtime_kind`` determines integration:
 .. code-block:: python
 
    gm = nami.GeneratorMatching(
-       field, op,
+       field,
        nami.RK4(steps=50),
+       parameterization=nami.generator_prediction(op),
        event_shape=(8,),
    )
    samples = gm().sample((64,))
@@ -614,7 +615,7 @@ Training
 
 .. code-block:: python
 
-   loss = nami.bridge_matching_loss(
+   loss = nami.losses.bridge_matching_loss(
        flow_field, score_field,
        x_noise=x_noise, x_data=x_data,
        interpolant=nami.BrownianBridgeInterpolant(),
@@ -629,11 +630,9 @@ Sampling
 After training, reconstruct the drift from the two fields and sample with a
 standard :class:`~nami.FlowMatching` or :class:`~nami.Diffusion` process.
 
-**Key components**: :func:`~nami.bridge_matching_loss`,
+**Key components**: :func:`~nami.losses.bridge_matching_loss`,
 :class:`~nami.BrownianBridgeInterpolant`,
-:class:`~nami.DriftFromVelocityScore`,
-:class:`~nami.ScoreFromEta`,
-:class:`~nami.ScoreFromRawNoise`.
+:class:`~nami.DriftFromVelocityScore`.
 
 
 Choosing a model
@@ -662,7 +661,7 @@ Choosing a model
      - ``regression_loss`` + ``generator_prediction``
      - ``GeneratorMatching``
    * - Schrodinger bridge (flow + score)
-     - ``bridge_matching_loss``
+     - ``losses.bridge_matching_loss``
      - ``FlowMatching`` / ``Diffusion``
 
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -168,7 +168,7 @@ Each workflow composes the same primitives differently.
      - :class:`~nami.Diffusion`
      - :class:`~nami.EulerMaruyama` / :class:`~nami.DPMSolverPP`
    * - Generator matching
-     - :func:`~nami.gm_loss` / :func:`~nami.cgm_loss`
+     - :func:`~nami.regression_loss` / :func:`~nami.cgm_loss`
      - :class:`~nami.GeneratorMatching`
      - :class:`~nami.RK4` / :class:`~nami.EulerMaruyama`
 
@@ -200,7 +200,8 @@ Not sure which workflow fits your problem? Use this decision guide:
      Training uses an external denoising objective; nami handles sampling.
 
    - **"I want to learn drift and diffusion jointly (operator-centric)."**
-     Use :func:`~nami.gm_loss` + :class:`~nami.GeneratorMatching`.
+     Use :func:`~nami.regression_loss` with :func:`~nami.generator_prediction`
+     (or :func:`~nami.cgm_loss`) + :class:`~nami.GeneratorMatching`.
      Generator matching subsumes the other models as special cases, but this is
      still a research-oriented part of the library.
 

--- a/docs/principles/model-families.rst
+++ b/docs/principles/model-families.rst
@@ -14,8 +14,8 @@ Every workflow in the library is built from the same primitive: a path
 objective regresses against a path-derived target. The differences between
 the families are differences in *what* the field predicts, *what target*
 the loss compares it to, and *what process* uses the trained field at
-inference time. The primitives — interpolants, schedules, solvers,
-distributions — are shared verbatim.
+inference time. The primitives (interpolants, schedules, solvers,
+distributions) are shared verbatim.
 
 Flow matching
 -------------
@@ -27,8 +27,8 @@ interpolant:
 
 .. math::
 
-   X_t = (1-t)\,x_{\mathrm{target}} + t\,x_{\mathrm{source}},
-   \qquad u_t = x_{\mathrm{source}} - x_{\mathrm{target}},
+   X_t = (1-t)\,x_{\mathrm{source}} + t\,x_{\mathrm{target}},
+   \qquad u_t = x_{\mathrm{target}} - x_{\mathrm{source}},
 
 and the loss regresses :math:`v_\theta(X_t, t)` against this constant
 conditional velocity. Sampling integrates the learned ODE from the source
@@ -149,9 +149,9 @@ operator parameters) sets the parameterisation. The loss
 bridges, operator-pairing for generator matching) sets *how* the prediction
 is identified from data. And what the process does at inference time
 (integrate an ODE, integrate an SDE, evaluate a one-step consistency
-function) sets the runtime cost and the kind of output. Everything else —
+function) sets the runtime cost and the kind of output. Everything else,
 the distribution interface, the solver protocol, the lazy-binding
-mechanism, the divergence estimators — is shared. If you find yourself
+mechanism, the divergence estimators, is shared. If you find yourself
 writing custom plumbing to switch between two families, that is usually a
 sign that something belongs in one of these four axes instead.
 
@@ -164,7 +164,7 @@ in this space live on the loss axis rather than the field-output axis.
 See also
 --------
 
-- :doc:`core-abstractions` — the primitives all the families share.
-- :doc:`parameterizations` — the second axis: what the field predicts.
-- :doc:`numerical-considerations` — the third axis: how the process
+- :doc:`core-abstractions`: the primitives all the families share.
+- :doc:`parameterizations`: the second axis: what the field predicts.
+- :doc:`numerical-considerations`: the third axis: how the process
   integrates.

--- a/docs/principles/numerical-considerations.rst
+++ b/docs/principles/numerical-considerations.rst
@@ -107,9 +107,9 @@ for that call only.
 See also
 --------
 
-- :doc:`core-abstractions` — where solvers and divergence estimators sit in
+- :doc:`core-abstractions`: where solvers and divergence estimators sit in
   the stack.
-- :doc:`parameterizations` — how the choice of parameterisation interacts
+- :doc:`parameterizations`: how the choice of parameterisation interacts
   with the SDE/ODE distinction.
-- :doc:`model-families` — which family each numerical choice is most
+- :doc:`model-families`: which family each numerical choice is most
   relevant to.

--- a/docs/principles/parameterizations.rst
+++ b/docs/principles/parameterizations.rst
@@ -37,14 +37,15 @@ Switching at sampling time
 --------------------------
 
 A model trained under one parameterisation often needs to be *used* under
-another at sampling time. nami exposes a small family of transforms for
-exactly this purpose. :class:`~nami.ScoreFromEta` turns a model that
-predicts :math:`\eta = \gamma(t) \nabla \log p_t` into a score; analogously
-:class:`~nami.ScoreFromRawNoise` handles a raw-noise prediction.
+another at sampling time. nami exposes the relevant conversions directly.
+For diffusion quantities, the functions in :mod:`nami.diffusion`
+(:func:`~nami.diffusion.eps_to_score`, :func:`~nami.diffusion.score_to_eps`,
+:func:`~nami.diffusion.score_to_x0`, :func:`~nami.diffusion.x0_to_score`)
+map between :math:`\varepsilon`, score, and :math:`x_0`.
 :class:`~nami.DriftFromVelocityScore` combines a velocity head and a score
 head into an SDE drift suitable for reverse-time integration. For diffusion
-models the analogous conversion is :math:`\nabla \log p_t(x) = -
-\varepsilon_\theta / \sigma(t)`, and is handled internally by
+models the conversion :math:`\nabla \log p_t(x) = -
+\varepsilon_\theta / \sigma(t)` is handled internally by
 :class:`~nami.Diffusion` when you pass
 :func:`~nami.epsilon_prediction`, :func:`~nami.score_prediction`, or
 :func:`~nami.x0_prediction` as the ``parameterization`` argument.
@@ -58,22 +59,22 @@ common failure mode in practice.
 A small concrete example
 ------------------------
 
-For interpolant-style models, the most common conversion is from a noise
-or eta head to a score. The transforms are thin wrappers that you compose
-with the field at sampling time:
+For stochastic-interpolant models the most common need is to combine a
+velocity head and a score head into an SDE drift at sampling time.
+:class:`~nami.DriftFromVelocityScore` is a thin wrapper that you compose
+with the two fields:
 
 .. code-block:: python
 
    import nami
 
    gamma = nami.BrownianGamma()
-   score = nami.ScoreFromEta(eta_model, gamma)       # eta -> score
-   drift = nami.DriftFromVelocityScore(v_model, score, gamma)
+   drift = nami.DriftFromVelocityScore(v_model, score_model, gamma)
 
-The velocity field, the score-converting wrapper, and the drift wrapper
-remain orthogonal: you can swap any one without touching the others, which
-is the whole point of keeping parameterisations explicit rather than
-hard-wired into a single class.
+The velocity field, the score field, and the drift wrapper remain
+orthogonal: you can swap any one without touching the others, which is the
+whole point of keeping parameterisations explicit rather than hard-wired
+into a single class.
 
 When to use which
 -----------------
@@ -83,16 +84,16 @@ matching, predict a velocity (the consistency function is built from it).
 For diffusion-style training, predict :math:`\varepsilon` against the
 standard objective and let :class:`~nami.Diffusion` handle the conversion
 at sampling time. For stochastic interpolants where SDE sampling is wanted,
-train a velocity *and* a score (or use the raw-noise head together with
-:class:`~nami.ScoreFromRawNoise`). For generator matching, predict raw
+train a velocity *and* a score and combine them with
+:class:`~nami.DriftFromVelocityScore`. For generator matching, predict raw
 operator parameters and let the operator interpret them.
 
 See also
 --------
 
-- :doc:`core-abstractions` — what a field is, and what ``event_ndim``
+- :doc:`core-abstractions`: what a field is, and what ``event_ndim``
   controls.
-- :doc:`model-families` — how the choice of parameterisation interacts with
+- :doc:`model-families`: how the choice of parameterisation interacts with
   the choice of process.
-- :doc:`numerical-considerations` — when the choice of parameterisation
+- :doc:`numerical-considerations`: when the choice of parameterisation
   starts to interact with the choice of solver.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -31,7 +31,7 @@ to :math:`t=1`.
 
    dim = 8
    field = nami.VelocityField(dim=dim)               # neural net predicting v(x, t)
-   base = nami.StandardNormal(event_shape=(dim,))     # source distribution at t=1
+   base = nami.StandardNormal(event_shape=(dim,))     # source distribution at t=0
    solver = nami.RK4(steps=50)                        # ODE integrator for sampling
    optim = torch.optim.Adam(field.parameters(), lr=1e-3)
 
@@ -149,7 +149,7 @@ To get **one-step log-densities**, add a log-prob head:
 
 .. code-block:: python
 
-   h_head = nami.ConsistencyHead(dim=dim)
+   h_head = nami.LogDensityHead(dim=dim)
    optim_h = torch.optim.Adam(
        list(field.parameters()) + list(h_head.parameters()), lr=1e-3,
    )
@@ -197,7 +197,7 @@ Everything else is identical — just swap the loss function:
 .. code-block:: python
 
    loss = nami.stochastic_fm_loss(
-       field, x_data, x_noise, gamma=nami.BrownianGamma(),
+       field, x_noise=x_noise, x_data=x_data, gamma=nami.BrownianGamma(),
    )
 
 .. admonition:: What This Does
@@ -256,7 +256,7 @@ regression. Here we use a deterministic path (drift only, ODE sampling).
    # The operator defines the functional form of the generator
    operator = nami.ItoGeneratorOperator(event_shape=(dim,), diffusion="none")
    # The field predicts the operator's parameters from (x, t)
-   field = nami.GeneratorField(dim=dim, param_shape=operator.parameter_shape)
+   field = nami.GeneratorField(dim, operator=operator)
    optim = torch.optim.Adam(field.parameters(), lr=1e-3)
 
    interpolant = nami.LinearInterpolant()
@@ -277,8 +277,8 @@ regression. Here we use a deterministic path (drift only, ODE sampling).
        optim.step()
 
    gm = nami.GeneratorMatching(
-       field, operator, nami.RK4(steps=50),
-       event_shape=(dim,),
+       field, nami.RK4(steps=50),
+       parameterization=parameterization, event_shape=(dim,),
    )
    samples = gm(None).sample((128,))
 


### PR DESCRIPTION
## Description

This PR fix's some of the drift present in the documentation, both in current pages not included in the published version and the main information present on the site.

The main fixes include updating the name of the `ConsistencyHead` to `LogDensityHead`, the use of `GeneratorMatching` and dropping old diffusion-based parameterisations that have since been updated, with a re-write of some of the how-to sections.

I've also fixed the inpainting toctree reference such that this book is available within the experiment page, and updated the interpolant example notebook.