### PR TITLE
feat: subpackage re-exports

### DIFF
--- a/src/nami/__init__.py
+++ b/src/nami/__init__.py
@@ -91,71 +91,89 @@ except ModuleNotFoundError:
     __version__ = "0+unknown"
 
 
-__all__ = [
-    "RK4",
-    "X0",
-    "Action",
-    "ActionHead",
-    "ActionMatching",
+# __all__ is grouped by the layer each symbol belongs to, so:
+# (Field -> Interpolant + Parameterization -> Loss -> Process + Solver),
+__all__ = [  # noqa: RUF022  (deliberately grouped by layer, not alphabetised)
+    # Fields: something that learns f(x, t, c)
+    "VelocityField",  # standard field to use
     "AdaLNVelocityField",
-    "AllMask",
-    "BregmanDivergence",
-    "BrownianBridgeInterpolant",
-    "BrownianGamma",
-    "CTMCField",
-    "CTMCGeneratorOperator",
-    "ConsistencyFlowMatching",
-    "CosineInterpolant",
-    "DPMSolverPP",
-    "DiagonalNormal",
-    "Diffusion",
-    "DriftFromVelocityScore",
-    "EDMSchedule",
-    "Epsilon",
-    "EulerMaruyama",
-    "ExactDivergence",
-    "FlowMatching",
-    "GammaSchedule",
-    "GaussianInterpolant",
-    "GeneratorField",
-    "GeneratorMatching",
-    "GeneratorOperator",
-    "GeneratorParams",
-    "Heun",
-    "HutchinsonDivergence",
-    "ItakuraSaito",
-    "ItoGeneratorOperator",
-    "KLDivergence",
-    "LinearInterpolant",
-    "LogDensityHead",
-    "MarkovizationDriftFromVelocityScore",
-    "MaskingInterpolant",
-    "Parameterization",
-    "ScaledBrownianGamma",
-    "Score",
-    "SquaredL2",
-    "StandardNormal",
-    "StochasticLinearInterpolant",
-    "TauLeapingSampler",
     "TransformerVelocityField",
-    "VESchedule",
-    "VPSchedule",
-    "VPrediction",
-    "Velocity",
-    "VelocityField",
+    "LogDensityHead",  # one-step log-density head
+    # more advanced fields: generator matching / CTMC / action / score-drift composites
+    "GeneratorField",
+    "CTMCField",
+    "ActionHead",
+    "DriftFromVelocityScore",
+    "MarkovizationDriftFromVelocityScore",
+    # Base distributions (source / t=0) for the process
+    "StandardNormal",
+    "DiagonalNormal",
+    "AllMask",  # discrete / masking transports
+    # Interpolants: the path between source and data
+    "LinearInterpolant",  # standard interpolant to use
+    "CosineInterpolant",
+    "StochasticLinearInterpolant",
+    "GaussianInterpolant",
+    "BrownianBridgeInterpolant",
+    "MaskingInterpolant",  # discrete / CTMC
+    # gamma schedules for stochastic interpolants
+    "BrownianGamma",
     "ZeroGamma",
-    "__version__",
-    "action_matching_loss",
-    "action_prediction",
-    "cgm_loss",
-    "consistency_loss",
+    "ScaledBrownianGamma",
+    "GammaSchedule",
+    # Parameterizations: what the field predicts
+    # factories (tie a field output to a training target)
+    "velocity_prediction",  # standard parameterization to use
     "epsilon_prediction",
-    "generator_prediction",
-    "log_density_consistency_loss",
-    "regression_loss",
     "score_prediction",
-    "stochastic_fm_loss",
-    "v_prediction",
-    "velocity_prediction",
     "x0_prediction",
+    "v_prediction",
+    "generator_prediction",  # generator matching
+    "action_prediction",  # action matching
+    # target markers (the types the factories produce) for the parameterizations
+    "Velocity",
+    "Epsilon",
+    "Score",
+    "X0",
+    "VPrediction",
+    "GeneratorParams",
+    "Action",
+    "Parameterization",
+    # Losses: pure training objectives
+    "regression_loss",  # standard loss to use
+    "consistency_loss",
+    "stochastic_fm_loss",
+    "log_density_consistency_loss",
+    "cgm_loss",  # conditional generator matching
+    "action_matching_loss",
+    # Bregman divergences (loss geometry for generator matching)
+    "BregmanDivergence",
+    "KLDivergence",
+    "SquaredL2",
+    "ItakuraSaito",
+    # Processes: sampling/likelihood(density)
+    "FlowMatching",  # standard process to use
+    "Diffusion",
+    "ConsistencyFlowMatching",
+    "GeneratorMatching",  # generator matching
+    "ActionMatching",
+    # Solvers: numerical schemes for the process
+    "RK4",  # solver to use for ODEs
+    "Heun",  # second-order solver to use for ODEs
+    "EulerMaruyama",  # solver to use for SDEs
+    "DPMSolverPP",  # fast solver for diffusion ODEs
+    "TauLeapingSampler",  # solver to use for discrete / CTMC
+    # Diffusion noise schedules
+    "VPSchedule",
+    "VESchedule",
+    "EDMSchedule",
+    # Divergence estimators (for log_prob)
+    "HutchinsonDivergence",  # for high-dimensional estimator
+    "ExactDivergence",  # for low-dimensional estimator
+    # Generator operators (advanced: generator matching)
+    "GeneratorOperator",
+    "ItoGeneratorOperator",
+    "CTMCGeneratorOperator",
+    # Meta: version information
+    "__version__",
 ]

--- a/src/nami/distributions/__init__.py
+++ b/src/nami/distributions/__init__.py
@@ -5,3 +5,8 @@ Thin wrappers around ``torch.distributions`` that expose the
 """
 
 from __future__ import annotations
+
+from nami.distributions.mask import AllMask
+from nami.distributions.normal import DiagonalNormal, StandardNormal
+
+__all__ = ["AllMask", "DiagonalNormal", "StandardNormal"]

--- a/src/nami/divergence/__init__.py
+++ b/src/nami/divergence/__init__.py
@@ -15,3 +15,9 @@ References
 """
 
 from __future__ import annotations
+
+from nami.divergence.base import DivergenceEstimator
+from nami.divergence.exact import ExactDivergence
+from nami.divergence.hutchinson import HutchinsonDivergence
+
+__all__ = ["DivergenceEstimator", "ExactDivergence", "HutchinsonDivergence"]

--- a/src/nami/fields/adaln.py
+++ b/src/nami/fields/adaln.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import torch
 from torch import nn
 
-from nami.components import SinusoidalTimeEmbedding
+from nami.components import SinusoidalTimeEmbedding, get_activation
 from nami.core.specs import (
     event_numel,
     flatten_event,
@@ -28,7 +28,6 @@ from nami.core.specs import (
 )
 from nami.fields._common import normalise_event_shape, validate_context
 from nami.fields.base import VectorField
-from nami.components import get_activation
 
 
 class _AdaLNBlock(nn.Module):

--- a/src/nami/losses/__init__.py
+++ b/src/nami/losses/__init__.py
@@ -16,7 +16,7 @@ et al., 2023), and Schrödinger-bridge matching
 
 from __future__ import annotations
 
-from nami.losses.action import action_matching_loss
+from nami.losses.action import action_matching_loss, action_prediction
 from nami.losses.bregman import (
     BregmanDivergence,
     ItakuraSaito,
@@ -36,6 +36,7 @@ __all__ = [
     "KLDivergence",
     "SquaredL2",
     "action_matching_loss",
+    "action_prediction",
     "bridge_matching_loss",
     "cgm_loss",
     "consistency_loss",

--- a/src/nami/schedules/__init__.py
+++ b/src/nami/schedules/__init__.py
@@ -12,3 +12,10 @@ References
 """
 
 from __future__ import annotations
+
+from nami.schedules.base import NoiseSchedule
+from nami.schedules.edm import EDMSchedule
+from nami.schedules.ve import VESchedule
+from nami.schedules.vp import VPSchedule
+
+__all__ = ["EDMSchedule", "NoiseSchedule", "VESchedule", "VPSchedule"]


### PR DESCRIPTION
### Description

This PR fixes some of the sub-module exports, such that pieces can be used from the dedicated module. I've also re-arranged the `__all__` export in the top-level package such that it's a bit more descriptive. This is the first stage towards re-organising and simplifying the top-level surface to be much more simple and intuitive.