### PR TITLE
fix: event shape validation and tensor spec

### DIFF
--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -1,8 +1,7 @@
 How-to guides
 =============
 
-Short, copy-pasteable recipes for common nami tasks. Each page assumes you
-already have rough orientation. For full signatures and defaults, see
+This page contains short examples for common nami workflows. For full signatures and default values, see
 :doc:`../api/index`.
 
 .. toctree::
@@ -23,25 +22,25 @@ already have rough orientation. For full signatures and defaults, see
 Recipes at a glance
 -------------------
 
-- :doc:`train-flow-matching` — the default starting point: regress a
+- :doc:`train-flow-matching`: the default starting point; regress a
   velocity field, sample with :class:`~nami.RK4`.
-- :doc:`train-stochastic-flow-matching` — add interpolant noise as a
+- :doc:`train-stochastic-flow-matching`: add interpolant noise as a
   training-time regulariser.
-- :doc:`train-consistency-flow-matching` — single-step sampling via a
+- :doc:`train-consistency-flow-matching`: single-step sampling via a
   consistency objective; experimental.
-- :doc:`train-generator-matching` — learn Itô generator parameters
+- :doc:`train-generator-matching`: learn Itô generator parameters
   directly; recovers FM, stochastic FM, and diffusion as special cases.
-- :doc:`sample-with-diffusion` — wrap a pretrained denoising model in
+- :doc:`sample-with-diffusion`: wrap a pretrained denoising model in
   :class:`~nami.Diffusion` to get a sampler.
-- :doc:`bridge-matching` — learn velocity and score jointly along a
+- :doc:`bridge-matching`: learn velocity and score jointly along a
   Brownian-bridge path.
-- :doc:`condition-on-context` — bind context :math:`c` at sampling time
+- :doc:`condition-on-context`: bind context :math:`c` at sampling time
   via the lazy process.
-- :doc:`swap-interpolant` — change the path geometry without touching the
+- :doc:`swap-interpolant`: change the path geometry without touching the
   rest of the pipeline.
-- :doc:`convert-parameterizations` — turn a score, an eta, or a raw-noise
+- :doc:`convert-parameterizations`: turn a score, an eta, or a raw-noise
   prediction into the quantity a process actually wants.
-- :doc:`compute-log-likelihood` — augmented ODE solve with Hutchinson or
+- :doc:`compute-log-likelihood`: augmented ODE solve with Hutchinson or
   exact divergence.
-- :doc:`sanity-check-zero-gamma` — verify stochastic FM reduces to
+- :doc:`sanity-check-zero-gamma`: verify stochastic FM reduces to
   deterministic FM at :math:`\gamma \equiv 0`.

--- a/docs/principles/core-abstractions.rst
+++ b/docs/principles/core-abstractions.rst
@@ -1,35 +1,32 @@
 Core abstractions
 =================
 
-nami is built from a small set of objects that compose along orthogonal axes,
-rather than a tall class hierarchy. Once you have a feel for what each one
-does and where the seams between them live, the rest of the library reads as
-combinations of these pieces.
+Nami is built from a small set of objects that compose along orthogonal axes. 
+Once you have a feel for what each one does and where the seams between them live, 
+the rest of the library reads as combinations of these pieces.
 
 The pieces
 ----------
 
-A **field** is a neural network with the contract
+A **field** is a neural network with the following interface:
 ``forward(x, t, c=None)``. It is the only object that holds learnable
 parameters. Fields predict whatever quantity the chosen training objective
 regresses against; a velocity, a score, raw noise, or a vector of operator
 parameters, and they declare an integer ``event_ndim`` so that the rest of
-the stack can recover the sample/batch/event split of any tensor without
-guessing.
+the sample/batch/event split of any tensor can be inferred.
 
-An **interpolant** is a deterministic recipe for the
+An **interpolant** is a deterministic path for the
 distribution :math:`p_t` that bridges source and target. It supplies a
-conditional sample :math:`X_t` and the conditional target the field is
-supposed to regress against; the linear interpolant, for instance, gives
+conditional sample :math:`X_t` and the conditional target that the field
+regresses against; the linear interpolant, for instance, gives
 :math:`X_t = (1-t)\,x_{\mathrm{noise}} + t\,x_{\mathrm{data}}` and the
 constant velocity :math:`x_{\mathrm{data}} - x_{\mathrm{noise}}`. Swapping
-the interpolant changes the geometry the field is asked to learn while
-leaving every other piece of the pipeline untouched.
+the interpolant thus changes the geometry the field learns.
 
 A **loss** ties a field to an interpolant. It samples a time, evaluates the
 interpolant's conditional target, evaluates the field, and returns a
-regression scalar. Losses are pure functions — they do not own state and do
-not bind context — which is what lets the same field be reused across very
+regression scalar. Losses are pure functions, meaningthey do not own state and do
+not bind context, which lets the same field be reused across very
 different objectives. :func:`~nami.regression_loss` and
 :func:`~nami.stochastic_fm_loss` both hand the same velocity field
 different conditional targets; the field never sees the difference.
@@ -37,7 +34,7 @@ different conditional targets; the field never sees the difference.
 A **process** is the runtime object that knows how to actually move samples
 around. This is done either by integrating an ODE or SDE from the source distribution,
 or by evaluating a one-step consistency function. Processes are the only
-place where the time direction is load-bearing: the loss is direction-free,
+place where the time direction is meaningful: the loss is direction-free,
 the field is direction-free, but the process integrates.
 
 A **solver** is the numerical scheme a process uses. ODE solvers
@@ -53,12 +50,11 @@ same sampling and log-density interface is acceptable.
 How they compose
 ----------------
 
-The composition is almost embarrassingly direct: build a field, pick a loss,
-train; then bundle the trained field with a distribution and a solver into a
-lazy process and call it. The same field can be reused across processes; the
-same solver can be reused across families; the same loss can be applied to
-any field with the right output signature. Nothing is welded to anything
-else.
+The composition is performed as follows: build a field, pick a loss,
+train, then bundle the trained field with a distribution and a solver into a
+lazy process and call it. The same field can be reused across processes. The
+same solver can be reused across families. The same loss can be applied to
+any field with the right output signature.
 
 .. code-block:: python
 
@@ -82,14 +78,14 @@ else.
    fm = nami.FlowMatching(field, nami.StandardNormal((8,)), nami.RK4(steps=50))
    samples = fm().sample((64,))
 
-This is why "flow matching", "diffusion", and "generator matching" do not
+This is why flow matching, diffusion, and generator matching do not
 appear as deep class hierarchies inside the library. They are not
 fundamentally different kinds of object; they are different (interpolant,
 field-output, loss, process) tuples over the same primitives. The loss is
-worth naming as its own axis even though it is a pure function: two
+worth identifying as its own axis even though it is a pure function: two
 families that predict the same quantity along the same path can still
 differ in how that prediction is identified from data, and many of the
-interesting research directions live exactly there. See
+interesting research directions follow on from this fact. See
 :doc:`model-families` for the longer version of that argument.
 
 Tensor layout
@@ -101,14 +97,11 @@ computations that share the same model parameters (typically one entry per
 conditioning context), and the trailing event axes describe a single data
 point. The integer property ``event_ndim`` on each field declares how many
 trailing dimensions count as event; everything to the left is treated as
-sample times batch. Most users never have to think about this — it is
-plumbing that lets the same field handle conditional and unconditional
-calls without reshape boilerplate.
+sample times batch.
 
-``event_ndim`` answers exactly one question: counting from the right, where
-does a single data point begin? Everything to its left — however many
-axes — is leading (sample times batch); nami never has to distinguish the
-two when peeling off the event. Concretely, a field's ``forward`` flattens
+``event_ndim`` is used to inform where a single data point begins, when counting from the right.
+Everything to its left, however many axes, is leading (sample times batch). Nami never has to 
+distinguish the two when peeling off the event dimensions. Concretely, a field's ``forward`` flattens
 only the trailing ``event_ndim`` axes and treats the rest as one leading
 block::
 
@@ -119,19 +112,19 @@ Worked example
 ~~~~~~~~~~~~~~
 
 Suppose ``x`` has shape ``(32, 500, 2)`` and one data point is a 2-vector.
-Then ``event_shape = (2,)`` and ``event_ndim = 1`` — one axis forms a
-sample, and the leading ``(32, 500)`` is sample times batch. nami does not
-care how you split that leading block into "32 samples" vs "500 batch";
+Then ``event_shape = (2,)`` and ``event_ndim = 1``. One axis forms a
+sample, and the leading ``(32, 500)`` is sample times batch. Nami does not
+care how that leading block is split into "32 samples" vs "500 batch";
 only ``event_ndim`` matters.
 
-The same tensor *rank* can imply different ``event_ndim``, which is why the
+The same tensor rank can imply different ``event_ndim``, which is why the
 property cannot be inferred from the shape alone and must be declared:
 
 .. list-table::
    :header-rows: 1
    :widths: 30 20 30 20
 
-   * - Your data point is…
+   * - Your data point is
      - ``event_shape``
      - a tensor might look like
      - ``event_ndim``
@@ -147,23 +140,23 @@ property cannot be inferred from the shape alone and must be declared:
      - ``(5,)``
      - ``(64, 5)``
      - ``1``
-   * - a 3×8×8 image
+   * - a 3 x 8 x 8 image
      - ``(3, 8, 8)``
      - ``(32, 500, 3, 8, 8)``
      - ``3``
 
 Note the last two rows of leading dims differ in count yet ``event_ndim``
 ignores that, and note that ``(32, 500, 2)`` and ``(32, 500, 3, 8, 8)`` are
-distinguished only by where the event begins — given a bare tensor, nami
-genuinely cannot tell whether ``(32, 500, 2)`` is ``(32, 500)`` leading ×
-``(2,)`` events or ``(32,)`` leading × ``(500, 2)`` events. Declaring
+distinguished only by where the event begins. For some bare tensor, nami
+genuinely cannot tell whether ``(32, 500, 2)`` is ``(32, 500)`` leading x
+``(2,)`` events or ``(32,)`` leading x ``(500, 2)`` events. Declaring
 ``event_ndim`` is the field author resolving that ambiguity.
 
-When a field *does* expose a concrete ``event_shape`` (not just an
+When a field does expose a concrete ``event_shape`` (not just an
 ``event_ndim``), nami validates the full shape against the base
 distribution at process-construction time, so a mismatch such as
 ``VelocityField(8)`` paired with ``StandardNormal((4,))`` raises
-immediately rather than surviving until ``sample()`` — both have rank
+immediately rather than surviving until ``sample()``; both have rank
 ``1``, so a rank-only check would miss it. Genuinely conditional fields,
 whose shape is unknown until a context is bound, skip this eager check and
 fall back to the rank check at bind time. Pass ``validate_args=False`` to a
@@ -171,14 +164,13 @@ process to opt out of validation entirely.
 
 Within a process, ``x_data`` is the endpoint at :math:`t=1` and ``x_noise``
 is the endpoint at :math:`t=0`; sampling integrates from :math:`t=0` up to
-:math:`t=1`. This is a library-level choice that keeps flow matching,
-consistency FM, stochastic FM, and generator matching on the same clock.
-The :class:`~nami.Diffusion` process is the exception, since it retains the
-diffusion-native orientation (data at small time, noise at large time)
-because the score-based reverse-time PF-ODE is intrinsic to that direction.
-In running prose elsewhere we let the variable names — ``x_data`` and
-``x_noise`` — carry the semantic, so that arguments about how the field
-behaves do not have to name endpoint values.
+:math:`t=1`. The :class:`~nami.Diffusion` process is the exception, 
+since it retains the diffusion-native orientation (data at small time, 
+noise at large time) because the score-based reverse-time PF-ODE is 
+intrinsic to that direction. In running prose elsewhere we let the 
+variable names (``x_data`` and ``x_noise``) carry the semantic, 
+so that arguments about how the field behaves do not have to name endpoint 
+values.
 
 See also
 --------

--- a/docs/principles/core-abstractions.rst
+++ b/docs/principles/core-abstractions.rst
@@ -105,6 +105,70 @@ sample times batch. Most users never have to think about this — it is
 plumbing that lets the same field handle conditional and unconditional
 calls without reshape boilerplate.
 
+``event_ndim`` answers exactly one question: counting from the right, where
+does a single data point begin? Everything to its left — however many
+axes — is leading (sample times batch); nami never has to distinguish the
+two when peeling off the event. Concretely, a field's ``forward`` flattens
+only the trailing ``event_ndim`` axes and treats the rest as one leading
+block::
+
+    x_flat = flatten_event(x, self.event_ndim)   # collapses the last event_ndim axes
+    lead   = x_flat.shape[:-1]                    # all remaining axes, together
+
+Worked example
+~~~~~~~~~~~~~~
+
+Suppose ``x`` has shape ``(32, 500, 2)`` and one data point is a 2-vector.
+Then ``event_shape = (2,)`` and ``event_ndim = 1`` — one axis forms a
+sample, and the leading ``(32, 500)`` is sample times batch. nami does not
+care how you split that leading block into "32 samples" vs "500 batch";
+only ``event_ndim`` matters.
+
+The same tensor *rank* can imply different ``event_ndim``, which is why the
+property cannot be inferred from the shape alone and must be declared:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 30 20
+
+   * - Your data point is…
+     - ``event_shape``
+     - a tensor might look like
+     - ``event_ndim``
+   * - a scalar
+     - ``()``
+     - ``(32, 500)``
+     - ``0``
+   * - a 2-vector
+     - ``(2,)``
+     - ``(32, 500, 2)``
+     - ``1``
+   * - a 5-vector
+     - ``(5,)``
+     - ``(64, 5)``
+     - ``1``
+   * - a 3×8×8 image
+     - ``(3, 8, 8)``
+     - ``(32, 500, 3, 8, 8)``
+     - ``3``
+
+Note the last two rows of leading dims differ in count yet ``event_ndim``
+ignores that, and note that ``(32, 500, 2)`` and ``(32, 500, 3, 8, 8)`` are
+distinguished only by where the event begins — given a bare tensor, nami
+genuinely cannot tell whether ``(32, 500, 2)`` is ``(32, 500)`` leading ×
+``(2,)`` events or ``(32,)`` leading × ``(500, 2)`` events. Declaring
+``event_ndim`` is the field author resolving that ambiguity.
+
+When a field *does* expose a concrete ``event_shape`` (not just an
+``event_ndim``), nami validates the full shape against the base
+distribution at process-construction time, so a mismatch such as
+``VelocityField(8)`` paired with ``StandardNormal((4,))`` raises
+immediately rather than surviving until ``sample()`` — both have rank
+``1``, so a rank-only check would miss it. Genuinely conditional fields,
+whose shape is unknown until a context is bound, skip this eager check and
+fall back to the rank check at bind time. Pass ``validate_args=False`` to a
+process to opt out of validation entirely.
+
 Within a process, ``x_data`` is the endpoint at :math:`t=1` and ``x_noise``
 is the endpoint at :math:`t=0`; sampling integrates from :math:`t=0` up to
 :math:`t=1`. This is a library-level choice that keeps flow matching,

--- a/docs/principles/lazy-binding.rst
+++ b/docs/principles/lazy-binding.rst
@@ -6,10 +6,9 @@ training and sampling. The naive way to do this is to branch: pass context
 when present, omit it when absent, and write each call site twice.
 ``LazyProcess`` and ``LazyDistribution`` exist so that you do not have to.
 
-The idea is to separate the moment a process is *configured* — when its
-field, distribution, and solver are decided — from the moment it is *bound*
-to a concrete piece of context. Configuration happens once, usually at
-training-script construction time. Binding happens at each call to the
+The idea is to separate the moment a process is configured, e.g. when its
+field, distribution, and solver are decided, from the moment it is bound
+to a concrete piece of context. Binding happens at each call site to the
 runtime object. The field's own signature does not change; the lazy wrapper
 absorbs the conditioning step so that the same sampling code runs whether
 context is present, absent, or different on every call.
@@ -34,9 +33,8 @@ entry point.
 
 Without lazy binding, conditional and unconditional execution often forces
 extra branching into training or sampling code. With it, the field defines
-*how* context enters the network and the process defines *when* that context
-is bound for sampling or likelihood evaluation, and the two responsibilities
-no longer leak into each other.
+how context enters the network and the process defines when that context
+is bound for sampling or likelihood evaluation.
 
 .. note::
 
@@ -65,10 +63,10 @@ inferred from the bound context. Fixed sources like
 Conceptually
 ------------
 
-The split is a design statement: the field is a pure function of
-``(x, t, c)``; the loss is a pure function of ``(field, x_noise, x_data)``;
-the lazy process is a small protocol that says "here is everything you need
-to sample once you tell me what to condition on".
+The field is a pure function of ``(x, t, c)``; the loss is a pure 
+function of ``(field, x_noise, x_data)``; the lazy process is a small 
+protocol that interfaces the sampling process once a condition is specified.
+
 
 See also
 --------

--- a/docs/principles/model-families.rst
+++ b/docs/principles/model-families.rst
@@ -1,7 +1,7 @@
 Model families as views of one object
 =====================================
 
-nami covers flow matching, diffusion, consistency flow matching, and
+Nami covers flow matching, diffusion, consistency flow matching, and
 generator matching. From a distance these look like four separate methods;
 from close up, they are four views of the same transport-map object. This
 essay walks through what each view emphasises and what genuinely differs.
@@ -99,12 +99,10 @@ Brownian-bridge path with a diagonal-diffusion operator is a full Itô
 diffusion model. The point of the framework is twofold. It provides the
 language in which "what is the difference between these methods?" has a
 precise answer: a path, an operator, a parameterisation, a loss. And it
-provides an extension point: new operators — non-diagonal diffusion, jump
+provides an extension point: new operators, non-diagonal diffusion, jump
 processes, anything expressible as a linear pairing with a basis of
-derivatives — drop in without rewriting the loss API or the process
-protocol. Most everyday problems do not need this generality, and flow
-matching has nicer training dynamics for the cases that fit it; but the
-framework is there for the cases that do.
+derivatives, can be dropped in without rewriting the loss API or the process
+protocol.
 
 Schrödinger bridge matching
 ---------------------------
@@ -112,14 +110,14 @@ Schrödinger bridge matching
 Bridge matching is the fifth family. Where flow matching and diffusion both
 transport a *fixed* source distribution onto the target, bridge matching
 learns the dynamics of a stochastic bridge between two distributions whose
-endpoints are coupled — most naturally, a forward diffusion bridge that
+endpoints are coupled, most naturally a forward diffusion bridge that
 respects a given coupling, in the spirit of the static Schrödinger bridge
 problem. It is the right family when the relationship between source and
 target is not "noise to data" but a genuine joint distribution: paired
 samples, optimal-transport couplings, or domain-translation tasks where
 both endpoints carry structure.
 
-In nami the workflow trains separate velocity and score heads on
+In Nami, the workflow trains separate velocity and score heads on
 Brownian-bridge path samples. The velocity head regresses the bridge's
 conditional drift; the score head regresses :math:`\nabla \log p_t` on the
 same path. At sampling time, :class:`~nami.DriftFromVelocityScore` combines
@@ -130,13 +128,13 @@ bridge-matching approach of Tong et al. and is closely related to the
 diffusion Schrödinger bridge matching of Shi et al. and to Peluchetti's
 bridge-mixture transports.
 
-What bridge matching makes visible — and what the other families hide — is
-that the *coupling* between source and target is a modelling choice in its
+What bridge matching makes visible, and what the other families hide, is
+that the coupling between source and target is a modelling choice in its
 own right. Flow matching and diffusion implicitly assume an independent
 coupling :math:`(x_{\mathrm{source}}, x_{\mathrm{target}}) \sim
 p_{\mathrm{source}} \otimes p_{\mathrm{target}}`; bridge matching lets the
-joint be whatever the problem actually has. The same primitives —
-interpolants, schedules, solvers — apply unchanged.
+joint be whatever the problem actually has. The same primitives,
+interpolants, schedules, solvers, apply unchanged.
 
 What actually differs
 ---------------------
@@ -146,7 +144,7 @@ Across the families, four things actually vary. The path
 intermediate marginals. What the field predicts (velocity, score, eps, x0,
 operator parameters) sets the parameterisation. The loss
 (regression-of-conditional-target, self-consistency, joint regression for
-bridges, operator-pairing for generator matching) sets *how* the prediction
+bridges, operator-pairing for generator matching) sets how the prediction
 is identified from data. And what the process does at inference time
 (integrate an ODE, integrate an SDE, evaluate a one-step consistency
 function) sets the runtime cost and the kind of output. Everything else,
@@ -156,8 +154,8 @@ writing custom plumbing to switch between two families, that is usually a
 sign that something belongs in one of these four axes instead.
 
 The loss axis deserves emphasis because it is the easiest to overlook: a
-consistency model and a flow-matching model can predict *the same*
-velocity, trained against *different* objectives, and produce very
+consistency model and a flow-matching model can predict the same
+velocity, trained against different objectives, and produce very
 different sampling behaviour. Many of the interesting research directions
 in this space live on the loss axis rather than the field-output axis.
 

--- a/docs/principles/parameterizations.rst
+++ b/docs/principles/parameterizations.rst
@@ -1,13 +1,13 @@
 Parameterizations
 =================
 
-A field in nami predicts *something*, but there is more than one useful
+A field in Nami predicts something, but there is more than one useful
 choice of what that something is. The same transport map can be specified by
 its velocity, by the score of its intermediate marginals, by the raw
 Gaussian noise added to an interpolant, by the clean-data target, or by a
 vector of operator parameters that an explicit operator object later
-interprets. These are not different methods — they are different
-parameterisations of one object — and nami lets you switch among them by
+interprets. These are not different methods, they are different
+parameterisations of one object, and Nami lets you switch among them by
 changing what the field predicts and which loss you regress it with.
 
 Why several parameterisations exist
@@ -21,8 +21,8 @@ parameterisation is what most pretrained diffusion checkpoints actually
 predict, and is numerically well-behaved when the schedule is variance-
 preserving. A clean-data (``X0``) head can be more stable when the noise
 level is high. A "V"-prediction blends velocity and noise terms in a way
-that is robust across schedules. And a generator-parameters head — the
-``GeneratorParams`` target — predicts an opaque vector that an operator
+that is robust across schedules. And a generator-parameters head, the
+``GeneratorParams`` target, predicts an opaque vector that an operator
 later linearly pairs with a basis of derivatives, which is what makes the
 generator-matching framework able to express drift, drift-plus-diffusion,
 and jump processes in one objective.

--- a/src/nami/core/specs.py
+++ b/src/nami/core/specs.py
@@ -107,7 +107,7 @@ def unflatten_event(x: torch.Tensor, event_shape: tuple[int, ...]) -> torch.Tens
 
 def validate_shapes(
     tensor: torch.Tensor,
-    event_ndim: int,
+    event_ndim: int | TensorSpec,
     expected_event_shape: tuple[int, ...] | None = None,
     batch_shape: tuple[int, ...] | None = None,
 ) -> None:
@@ -115,13 +115,25 @@ def validate_shapes(
 
     Args:
         tensor (torch.Tensor): Tensor to validate.
-        event_ndim (int): Number of trailing event dimensions.
+        event_ndim (int | TensorSpec): Number of trailing event dimensions,
+            or a :class:`TensorSpec` supplying both the event rank and the
+            expected event shape (and dtype, when constrained).
         expected_event_shape (tuple[int, ...] | None): Expected event shape.
+            Ignored when a :class:`TensorSpec` is given.
         batch_shape (tuple[int, ...] | None): Expected leading shape.
 
     Raises:
         ValueError: If ``event_ndim`` is invalid or a shape check fails.
+        TypeError: If a spec constrains dtype and the tensor dtype differs.
     """
+    if isinstance(event_ndim, TensorSpec):
+        spec = event_ndim
+        if spec.dtype is not None and tensor.dtype != spec.dtype:
+            msg = f"dtype mismatch: expected {spec.dtype}, got {tensor.dtype}"
+            raise TypeError(msg)
+        event_ndim = spec.event_ndim
+        expected_event_shape = spec.event_shape
+
     if event_ndim < 0:
         msg = "event_ndim must be >= 0"
         raise ValueError(msg)

--- a/src/nami/distributions/mask.py
+++ b/src/nami/distributions/mask.py
@@ -13,7 +13,7 @@ import torch
 from torch.distributions import Distribution
 from torch.types import _size
 
-from nami.core.specs import as_tuple
+from nami.core.specs import TensorSpec, as_tuple
 
 _EMPTY_SIZE = torch.Size()
 
@@ -22,8 +22,10 @@ class AllMask(Distribution):
     """Degenerate base that returns the all-mask token state.
 
     Args:
-        event_shape (tuple[int, ...] | int): Shape of a single event (token
-            coordinates).
+        event_shape (tuple[int, ...] | int | None): Shape of a single event
+            (token coordinates). Mutually exclusive with ``spec``.
+        spec (TensorSpec | None): Event specification supplying
+            ``event_shape``. Mutually exclusive with ``event_shape``.
         mask_index (int): Vocabulary index of the absorbing mask token.
         batch_shape (tuple[int, ...] | int | None): Optional batch shape.
         device (torch.device | None): Device for sampled tensors.
@@ -34,14 +36,26 @@ class AllMask(Distribution):
 
     def __init__(
         self,
-        event_shape: tuple[int, ...] | int,
+        event_shape: tuple[int, ...] | int | None = None,
         *,
+        spec: TensorSpec | None = None,
         mask_index: int,
         batch_shape: tuple[int, ...] | int | None = None,
         device: torch.device | None = None,
         validate_args: bool = False,
     ):
-        self._event_shape_ = as_tuple(event_shape)
+        if spec is not None:
+            if event_shape is not None:
+                msg = "pass either spec or event_shape, not both"
+                raise ValueError(msg)
+        elif event_shape is None:
+            msg = "either event_shape or spec is required"
+            raise ValueError(msg)
+        else:
+            spec = TensorSpec(as_tuple(event_shape))
+
+        self._spec = spec
+        self._event_shape_ = spec.event_shape
         self._batch_shape_ = as_tuple(batch_shape)
         self.mask_index = int(mask_index)
         self.device = device
@@ -50,6 +64,10 @@ class AllMask(Distribution):
             event_shape=torch.Size(self._event_shape_),
             validate_args=validate_args,
         )
+
+    @property
+    def spec(self) -> TensorSpec:
+        return self._spec
 
     def sample(self, sample_shape: _size = _EMPTY_SIZE) -> torch.Tensor:
         shape = tuple(sample_shape) + self._batch_shape_ + self._event_shape_

--- a/src/nami/distributions/normal.py
+++ b/src/nami/distributions/normal.py
@@ -13,13 +13,26 @@ import torch
 from torch.distributions import Distribution, Independent, Normal
 from torch.types import _size
 
-from nami.core.specs import as_tuple
+from nami.core.specs import TensorSpec, as_tuple
 
 _EMPTY_SIZE = torch.Size()
 
 
 class StandardNormal(Distribution):
-    """Isotropic ``N(0, I)`` over ``event_shape`` with explicit batch shape."""
+    """Isotropic ``N(0, I)`` over ``event_shape`` with explicit batch shape.
+
+    Args:
+        event_shape (tuple[int, ...] | int | None): Shape of a single event.
+            Mutually exclusive with ``spec``.
+        spec (TensorSpec | None): Event specification supplying both
+            ``event_shape`` and ``dtype``. Mutually exclusive with the
+            explicit ``event_shape`` / ``dtype`` arguments.
+        batch_shape (tuple[int, ...] | int | None): Optional batch shape.
+        device (torch.device | None): Device for the distribution tensors.
+        dtype (torch.dtype | None): Tensor dtype. Mutually exclusive with
+            ``spec``.
+        validate_args (bool): Whether torch validates arguments.
+    """
 
     has_rsample = True
     arg_constraints: ClassVar[
@@ -28,15 +41,28 @@ class StandardNormal(Distribution):
 
     def __init__(
         self,
-        event_shape: tuple[int, ...] | int,
+        event_shape: tuple[int, ...] | int | None = None,
         *,
+        spec: TensorSpec | None = None,
         batch_shape: tuple[int, ...] | int | None = None,
         device: torch.device | None = None,
         dtype: torch.dtype | None = None,
         validate_args: bool = True,
     ):
-        self._event_shape = as_tuple(event_shape)
+        if spec is not None:
+            if event_shape is not None or dtype is not None:
+                msg = "pass either spec or explicit event_shape/dtype, not both"
+                raise ValueError(msg)
+        elif event_shape is None:
+            msg = "either event_shape or spec is required"
+            raise ValueError(msg)
+        else:
+            spec = TensorSpec(as_tuple(event_shape), dtype=dtype)
+
+        self._spec = spec
+        self._event_shape = spec.event_shape
         self._batch_shape = as_tuple(batch_shape)
+        dtype = spec.dtype
         shape = self._batch_shape + self._event_shape
         loc = torch.zeros(shape, device=device, dtype=dtype)
         scale = torch.ones(shape, device=device, dtype=dtype)
@@ -67,6 +93,10 @@ class StandardNormal(Distribution):
     def variance(self) -> torch.Tensor:
         return self._base.variance
 
+    @property
+    def spec(self) -> TensorSpec:
+        return self._spec
+
     def expand(
         self, batch_shape: _size, _instance: Distribution | None = None
     ) -> StandardNormal:
@@ -75,6 +105,7 @@ class StandardNormal(Distribution):
         Distribution.__init__(
             new, base.batch_shape, base.event_shape, validate_args=False
         )
+        new._spec = self._spec
         new._event_shape = self._event_shape
         new._batch_shape = tuple(batch_shape)
         new._base = base
@@ -99,7 +130,10 @@ class DiagonalNormal(Distribution):
         if event_ndim:
             base = Independent(base, event_ndim)
         self._base = base
-        self.event_ndim = event_ndim
+        self._spec = TensorSpec(
+            tuple(loc.shape[-event_ndim:]) if event_ndim else (),
+            dtype=loc.dtype,
+        )
         super().__init__(
             batch_shape=base.batch_shape,
             event_shape=base.event_shape,
@@ -123,6 +157,14 @@ class DiagonalNormal(Distribution):
     def variance(self) -> torch.Tensor:
         return self._base.variance
 
+    @property
+    def spec(self) -> TensorSpec:
+        return self._spec
+
+    @property
+    def event_ndim(self) -> int:
+        return self._spec.event_ndim
+
     def expand(
         self, batch_shape: _size, _instance: Distribution | None = None
     ) -> DiagonalNormal:
@@ -132,5 +174,5 @@ class DiagonalNormal(Distribution):
             new, base.batch_shape, base.event_shape, validate_args=False
         )
         new._base = base
-        new.event_ndim = self.event_ndim
+        new._spec = self._spec
         return new

--- a/src/nami/divergence/exact.py
+++ b/src/nami/divergence/exact.py
@@ -33,7 +33,8 @@ class ExactDivergence(DivergenceEstimator):
     def __call__(
         self, field, x: torch.Tensor, t: torch.Tensor, c: torch.Tensor | None
     ) -> torch.Tensor:
-        event_ndim = getattr(field, "event_ndim", None)
+        spec = getattr(field, "spec", None)
+        event_ndim = spec.event_ndim if spec is not None else getattr(field, "event_ndim", None)
         if event_ndim is None:
             msg = "field.event_ndim is required for divergence"
             raise ValueError(msg)

--- a/src/nami/divergence/hutchinson.py
+++ b/src/nami/divergence/hutchinson.py
@@ -45,7 +45,8 @@ class HutchinsonDivergence(DivergenceEstimator):
     def __call__(
         self, field, x: torch.Tensor, t: torch.Tensor, c: torch.Tensor | None
     ) -> torch.Tensor:
-        event_ndim = getattr(field, "event_ndim", None)
+        spec = getattr(field, "spec", None)
+        event_ndim = spec.event_ndim if spec is not None else getattr(field, "event_ndim", None)
         if event_ndim is None:
             msg = "field.event_ndim is required for divergence"
             raise ValueError(msg)

--- a/src/nami/fields/action.py
+++ b/src/nami/fields/action.py
@@ -4,7 +4,7 @@ import torch
 from torch import nn
 
 from nami.components import MLPBackbone, ScalarTimeEmbedding
-from nami.core.specs import event_numel, flatten_event, validate_shapes
+from nami.core.specs import TensorSpec, flatten_event, validate_shapes
 from nami.fields._common import normalise_event_shape, validate_context
 
 
@@ -62,9 +62,8 @@ class ActionHead(nn.Module):
             msg = f"condition_dim must be non-negative, got {condition_dim}"
             raise ValueError(msg)
 
-        self.event_shape = normalise_event_shape(dim)
+        self.spec = TensorSpec(normalise_event_shape(dim))
         self.condition_dim = int(condition_dim)
-        self.flat_dim = event_numel(self.event_shape)
         self.time_embedding = ScalarTimeEmbedding()
         self.backbone = MLPBackbone(
             self.flat_dim + 1 + self.condition_dim,
@@ -77,8 +76,16 @@ class ActionHead(nn.Module):
         )
 
     @property
+    def event_shape(self) -> tuple[int, ...]:
+        return self.spec.event_shape
+
+    @property
     def event_ndim(self) -> int:
-        return len(self.event_shape)
+        return self.spec.event_ndim
+
+    @property
+    def flat_dim(self) -> int:
+        return self.spec.numel
 
     def forward(
         self,
@@ -94,7 +101,7 @@ class ActionHead(nn.Module):
             Scalar potential per sample.  Its gradient w.r.t. ``x`` is
             the velocity used by :class:`~nami.ActionMatching`.
         """
-        validate_shapes(x, self.event_ndim, expected_event_shape=self.event_shape)
+        validate_shapes(x, self.spec)
         x_flat = flatten_event(x, self.event_ndim)
         lead_shape = tuple(x_flat.shape[:-1])
         t_features = self.time_embedding(

--- a/src/nami/fields/adaln.py
+++ b/src/nami/fields/adaln.py
@@ -21,7 +21,7 @@ from torch import nn
 
 from nami.components import SinusoidalTimeEmbedding, get_activation
 from nami.core.specs import (
-    event_numel,
+    TensorSpec,
     flatten_event,
     unflatten_event,
     validate_shapes,
@@ -127,9 +127,8 @@ class AdaLNVelocityField(VectorField):
             msg = f"unknown activation: {activation!r}"
             raise ValueError(msg) from exc
 
-        self.event_shape = normalise_event_shape(dim)
+        self.spec = TensorSpec(normalise_event_shape(dim))
         self.condition_dim = int(condition_dim)
-        self.flat_dim = event_numel(self.event_shape)
         self.layers = int(layers)
         self.hidden = int(hidden)
 
@@ -164,8 +163,16 @@ class AdaLNVelocityField(VectorField):
         )
 
     @property
+    def event_shape(self) -> tuple[int, ...]:
+        return self.spec.event_shape
+
+    @property
     def event_ndim(self) -> int:
-        return len(self.event_shape)
+        return self.spec.event_ndim
+
+    @property
+    def flat_dim(self) -> int:
+        return self.spec.numel
 
     def forward(
         self,
@@ -173,7 +180,7 @@ class AdaLNVelocityField(VectorField):
         t: torch.Tensor,
         c: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        validate_shapes(x, self.event_ndim, expected_event_shape=self.event_shape)
+        validate_shapes(x, self.spec)
         x_flat = flatten_event(x, self.event_ndim)
         lead_shape = tuple(x_flat.shape[:-1])
         validate_context(c, self.condition_dim, lead_shape)

--- a/src/nami/fields/consistency.py
+++ b/src/nami/fields/consistency.py
@@ -4,7 +4,7 @@ import torch
 from torch import nn
 
 from nami.components import MLPBackbone, ScalarTimeEmbedding
-from nami.core.specs import event_numel, flatten_event, validate_shapes
+from nami.core.specs import TensorSpec, flatten_event, validate_shapes
 from nami.fields._common import normalise_event_shape, validate_context
 
 
@@ -50,9 +50,8 @@ class LogDensityHead(nn.Module):
             msg = f"condition_dim must be non-negative, got {condition_dim}"
             raise ValueError(msg)
 
-        self.event_shape = normalise_event_shape(dim)
+        self.spec = TensorSpec(normalise_event_shape(dim))
         self.condition_dim = int(condition_dim)
-        self.flat_dim = event_numel(self.event_shape)
         self.time_embedding = ScalarTimeEmbedding()
         self.backbone = MLPBackbone(
             self.flat_dim + 1 + self.condition_dim,
@@ -65,8 +64,16 @@ class LogDensityHead(nn.Module):
         )
 
     @property
+    def event_shape(self) -> tuple[int, ...]:
+        return self.spec.event_shape
+
+    @property
     def event_ndim(self) -> int:
-        return len(self.event_shape)
+        return self.spec.event_ndim
+
+    @property
+    def flat_dim(self) -> int:
+        return self.spec.numel
 
     def forward(
         self,
@@ -81,7 +88,7 @@ class LogDensityHead(nn.Module):
         Tensor, shape ``(*lead,)``
             Scalar log-density prediction per sample.
         """
-        validate_shapes(x, self.event_ndim, expected_event_shape=self.event_shape)
+        validate_shapes(x, self.spec)
         x_flat = flatten_event(x, self.event_ndim)
         lead_shape = tuple(x_flat.shape[:-1])
         t_features = self.time_embedding(

--- a/src/nami/fields/generator.py
+++ b/src/nami/fields/generator.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import torch
 
 from nami.components import MLPBackbone, ScalarTimeEmbedding
-from nami.core.specs import event_numel, flatten_event, validate_shapes
+from nami.core.specs import TensorSpec, flatten_event, validate_shapes
 from nami.fields._common import normalise_event_shape, validate_context
 from nami.fields.base import VectorField
 
@@ -40,7 +40,7 @@ class GeneratorField(VectorField):
             msg = f"condition_dim must be non-negative, got {condition_dim}"
             raise ValueError(msg)
 
-        self.event_shape = normalise_event_shape(dim)
+        self.spec = TensorSpec(normalise_event_shape(dim))
         if tuple(operator.event_shape) != self.event_shape:
             msg = (
                 f"operator.event_shape must match dim: expected {self.event_shape}, "
@@ -50,9 +50,7 @@ class GeneratorField(VectorField):
 
         self.operator = operator
         self.condition_dim = int(condition_dim)
-        self.flat_dim = event_numel(self.event_shape)
-        self.parameter_shape = tuple(operator.parameter_shape)
-        self.parameter_dim = event_numel(self.parameter_shape)
+        self.param_spec = TensorSpec(tuple(operator.parameter_shape))
         self.time_embedding = ScalarTimeEmbedding()
         self.backbone = MLPBackbone(
             self.flat_dim + 1 + self.condition_dim,
@@ -65,8 +63,24 @@ class GeneratorField(VectorField):
         )
 
     @property
+    def event_shape(self) -> tuple[int, ...]:
+        return self.spec.event_shape
+
+    @property
     def event_ndim(self) -> int:
-        return len(self.event_shape)
+        return self.spec.event_ndim
+
+    @property
+    def flat_dim(self) -> int:
+        return self.spec.numel
+
+    @property
+    def parameter_shape(self) -> tuple[int, ...]:
+        return self.param_spec.event_shape
+
+    @property
+    def parameter_dim(self) -> int:
+        return self.param_spec.numel
 
     def forward(
         self,
@@ -74,7 +88,7 @@ class GeneratorField(VectorField):
         t: torch.Tensor,
         c: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        validate_shapes(x, self.event_ndim, expected_event_shape=self.event_shape)
+        validate_shapes(x, self.spec)
         x_flat = flatten_event(x, self.event_ndim)
         lead_shape = tuple(x_flat.shape[:-1])
         t_features = self.time_embedding(

--- a/src/nami/fields/transformer_velocity.py
+++ b/src/nami/fields/transformer_velocity.py
@@ -19,7 +19,7 @@ import torch
 from torch import nn
 
 from nami.components import SinusoidalTimeEmbedding, TransformerBackbone
-from nami.core.specs import event_numel, flatten_event, unflatten_event, validate_shapes
+from nami.core.specs import TensorSpec, flatten_event, unflatten_event, validate_shapes
 from nami.fields._common import normalise_event_shape, validate_context
 from nami.fields.base import VectorField
 
@@ -57,9 +57,8 @@ class TransformerVelocityField(VectorField):
             msg = f"condition_dim must be non-negative, got {condition_dim}"
             raise ValueError(msg)
 
-        self.event_shape = normalise_event_shape(dim)
+        self.spec = TensorSpec(normalise_event_shape(dim))
         self.condition_dim = int(condition_dim)
-        self.flat_dim = event_numel(self.event_shape)
         self.time_embedding = SinusoidalTimeEmbedding(time_dim)
         self.input_proj = nn.Linear(1 + time_dim, model_dim)
         self.backbone = TransformerBackbone(
@@ -77,8 +76,16 @@ class TransformerVelocityField(VectorField):
         )
 
     @property
+    def event_shape(self) -> tuple[int, ...]:
+        return self.spec.event_shape
+
+    @property
     def event_ndim(self) -> int:
-        return len(self.event_shape)
+        return self.spec.event_ndim
+
+    @property
+    def flat_dim(self) -> int:
+        return self.spec.numel
 
     def _context_tokens(
         self,
@@ -96,7 +103,7 @@ class TransformerVelocityField(VectorField):
         t: torch.Tensor,
         c: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        validate_shapes(x, self.event_ndim, expected_event_shape=self.event_shape)
+        validate_shapes(x, self.spec)
         x_flat = flatten_event(x, self.event_ndim)
         lead_shape = tuple(x_flat.shape[:-1])
 

--- a/src/nami/fields/velocity.py
+++ b/src/nami/fields/velocity.py
@@ -15,7 +15,7 @@ import torch
 
 from nami.components import MLPBackbone, ScalarTimeEmbedding
 from nami.core.specs import (
-    event_numel,
+    TensorSpec,
     flatten_event,
     unflatten_event,
     validate_shapes,
@@ -59,9 +59,8 @@ class VelocityField(VectorField):
             msg = f"condition_dim must be non-negative, got {condition_dim}"
             raise ValueError(msg)
 
-        self.event_shape = normalise_event_shape(dim)
+        self.spec = TensorSpec(normalise_event_shape(dim))
         self.condition_dim = int(condition_dim)
-        self.flat_dim = event_numel(self.event_shape)
         self.time_embedding = ScalarTimeEmbedding()
         self.backbone = MLPBackbone(
             self.flat_dim + 1 + self.condition_dim,
@@ -74,8 +73,16 @@ class VelocityField(VectorField):
         )
 
     @property
+    def event_shape(self) -> tuple[int, ...]:
+        return self.spec.event_shape
+
+    @property
     def event_ndim(self) -> int:
-        return len(self.event_shape)
+        return self.spec.event_ndim
+
+    @property
+    def flat_dim(self) -> int:
+        return self.spec.numel
 
     def forward(
         self,
@@ -83,7 +90,7 @@ class VelocityField(VectorField):
         t: torch.Tensor,
         c: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        validate_shapes(x, self.event_ndim, expected_event_shape=self.event_shape)
+        validate_shapes(x, self.spec)
         x_flat = flatten_event(x, self.event_ndim)
         lead_shape = tuple(x_flat.shape[:-1])
         t_features = self.time_embedding(

--- a/src/nami/generators/base.py
+++ b/src/nami/generators/base.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING
 
 import torch
 
+from nami.core.specs import TensorSpec
+
 if TYPE_CHECKING:
     from nami.losses.bregman import BregmanDivergence
 
@@ -45,12 +47,17 @@ class GeneratorOperator:
         return self._runtime_kind
 
     @property
+    def spec(self) -> TensorSpec:
+        """Event specification; the single source of shape truth."""
+        return TensorSpec(self.event_shape)
+
+    @property
     def event_shape(self) -> tuple[int, ...]:
         raise NotImplementedError
 
     @property
     def event_ndim(self) -> int:
-        return len(self.event_shape)
+        return self.spec.event_ndim
 
     @property
     def parameter_shape(self) -> tuple[int, ...]:

--- a/src/nami/generators/ctmc.py
+++ b/src/nami/generators/ctmc.py
@@ -44,6 +44,7 @@ from typing import TYPE_CHECKING
 
 import torch
 
+from nami.core.specs import TensorSpec
 from nami.fields._common import normalise_event_shape
 from nami.generators.base import GeneratorOperator
 
@@ -75,18 +76,22 @@ class CTMCGeneratorOperator(GeneratorOperator):
             msg = f"num_states must be at least 2, got {num_states}"
             raise ValueError(msg)
         self.num_states = int(num_states)
-        self._event_shape = normalise_event_shape(event_shape)
+        self._spec = TensorSpec(normalise_event_shape(event_shape))
         self.eps = float(eps)
         super().__init__(runtime_kind="jump")
 
     @property
+    def spec(self) -> TensorSpec:
+        return self._spec
+
+    @property
     def event_shape(self) -> tuple[int, ...]:
-        return self._event_shape
+        return self._spec.event_shape
 
     @property
     def parameter_shape(self) -> tuple[int, ...]:
         # one categorical distribution over the K data tokens per coordinate.
-        return (*self._event_shape, self.num_states)
+        return (*self.event_shape, self.num_states)
 
     @property
     def mask_index(self) -> int:

--- a/src/nami/generators/operators.py
+++ b/src/nami/generators/operators.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 import torch
 import torch.nn.functional as F
 
-from nami.core.specs import validate_shapes
+from nami.core.specs import TensorSpec, validate_shapes
 from nami.fields._common import normalise_event_shape
 from nami.generators.base import GeneratorOperator
 
@@ -54,14 +54,18 @@ class ItoGeneratorOperator(GeneratorOperator):
             msg = f"min_scale must be non-negative, got {min_scale}"
             raise ValueError(msg)
 
-        self._event_shape = normalise_event_shape(event_shape)
+        self._spec = TensorSpec(normalise_event_shape(event_shape))
         self.diffusion_mode = diffusion
         self.min_scale = float(min_scale)
         super().__init__(runtime_kind="ode" if diffusion == "none" else "sde")
 
     @property
+    def spec(self) -> TensorSpec:
+        return self._spec
+
+    @property
     def event_shape(self) -> tuple[int, ...]:
-        return self._event_shape
+        return self._spec.event_shape
 
     @property
     def parameter_shape(self) -> tuple[int, ...]:
@@ -84,7 +88,7 @@ class ItoGeneratorOperator(GeneratorOperator):
         drift: torch.Tensor,
         diffusion: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        validate_shapes(drift, self.event_ndim, expected_event_shape=self.event_shape)
+        validate_shapes(drift, self.spec)
         if self.diffusion_mode == "none":
             if diffusion is not None:
                 msg = "diffusion parameters are not used when diffusion='none'"
@@ -94,11 +98,7 @@ class ItoGeneratorOperator(GeneratorOperator):
         if diffusion is None:
             msg = "diffusion tensor is required when diffusion='diagonal'"
             raise ValueError(msg)
-        validate_shapes(
-            diffusion,
-            self.event_ndim,
-            expected_event_shape=self.event_shape,
-        )
+        validate_shapes(diffusion, self.spec)
         return torch.stack((drift, diffusion), dim=-(self.event_ndim + 1))
 
     def project(self, params: torch.Tensor) -> torch.Tensor:

--- a/src/nami/processes/_common.py
+++ b/src/nami/processes/_common.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import torch
 
+from nami.core.specs import TensorSpec
+
 
 def cast_time(t: float | torch.Tensor, like: torch.Tensor) -> torch.Tensor:
     """Cast time values to match a reference tensor.
@@ -77,6 +79,54 @@ def model_device_dtype(
     return None, None
 
 
+def resolve_event_ndim_override(
+    spec: TensorSpec | None, event_ndim: int | None
+) -> int | None:
+    """Resolve an event-rank constructor override from a spec or explicit rank.
+
+    Args:
+        spec (TensorSpec | None): Event specification, when supplied.
+        event_ndim (int | None): Explicit event rank, when supplied.
+
+    Returns:
+        int | None: The resolved rank, or ``None`` when neither is given.
+
+    Raises:
+        ValueError: If both ``spec`` and ``event_ndim`` are given.
+    """
+    if spec is not None and event_ndim is not None:
+        msg = "pass either spec or event_ndim, not both"
+        raise ValueError(msg)
+    if spec is not None:
+        return spec.event_ndim
+    return event_ndim
+
+
+def resolve_event_shape_override(
+    spec: TensorSpec | None, event_shape: tuple[int, ...] | None
+) -> tuple[int, ...] | None:
+    """Resolve an event-shape constructor override from a spec or explicit shape.
+
+    Args:
+        spec (TensorSpec | None): Event specification, when supplied.
+        event_shape (tuple[int, ...] | None): Explicit event shape, when
+            supplied.
+
+    Returns:
+        tuple[int, ...] | None: The resolved shape, or ``None`` when neither
+        is given.
+
+    Raises:
+        ValueError: If both ``spec`` and ``event_shape`` are given.
+    """
+    if spec is not None and event_shape is not None:
+        msg = "pass either spec or event_shape, not both"
+        raise ValueError(msg)
+    if spec is not None:
+        return spec.event_shape
+    return event_shape
+
+
 def resolve_event_ndim(field, fallback: int | None = None) -> int:
     """Resolve the event rank for a field.
 
@@ -101,20 +151,88 @@ def validate_base_event_ndim(
     base: torch.distributions.Distribution,
     event_ndim: int,
     *,
+    field_event_shape: tuple[int, ...] | None = None,
     message: str = "field.event_ndim does not match base.event_shape",
 ) -> None:
-    """Validate a base distribution event rank.
+    """Validate a base distribution event rank, and shape when known.
+
+    The rank check (``len(base.event_shape) == event_ndim``) always runs.
+    When ``field_event_shape`` is supplied — i.e. the field exposes a
+    concrete event shape rather than only a rank — the full tuples are
+    compared as well, so a ``(2,)`` field paired with a ``(4,)`` base is
+    rejected even though both have rank ``1``.
 
     Args:
         base (torch.distributions.Distribution): Base distribution.
         event_ndim (int): Expected event rank.
+        field_event_shape (tuple[int, ...] | None): The field's concrete
+            event shape, when it exposes one. ``None`` falls back to the
+            rank-only check.
         message (str): Error message used on mismatch.
 
     Raises:
-        ValueError: If ``len(base.event_shape) != event_ndim``.
+        ValueError: If the base event rank differs from ``event_ndim``, or
+            if ``field_event_shape`` is given and differs from
+            ``base.event_shape``.
     """
-    if len(base.event_shape) != event_ndim:
+    base_shape = tuple(base.event_shape)
+    if len(base_shape) != event_ndim:
         raise ValueError(message)
+    if field_event_shape is not None and tuple(field_event_shape) != base_shape:
+        msg = (
+            f"{message}: field event_shape {tuple(field_event_shape)} "
+            f"!= base event_shape {base_shape}"
+        )
+        raise ValueError(msg)
+
+
+def _static_event_shape(obj: object) -> tuple[int, ...] | None:
+    """Best-effort concrete ``event_shape`` behind a field or its lazy wrapper.
+
+    Unwraps the ``Unconditional*`` adapters (which hold the concrete object
+    in ``_field`` / ``_dist``) by duck typing, so no import of
+    :mod:`nami.lazy` is needed. Returns ``None`` when no concrete shape is
+    reachable — the genuinely conditional case, where the shape is unknown
+    until a context is bound.
+    """
+    if obj is None:
+        return None
+    inner = getattr(obj, "_field", None)
+    if inner is None:
+        inner = getattr(obj, "_dist", None)
+    target = obj if inner is None else inner
+    shape = getattr(target, "event_shape", None)
+    return None if shape is None else tuple(shape)
+
+
+def eager_validate_base_event_shape(
+    field: object,
+    base: object,
+    *,
+    message: str = "field.event_shape does not match base.event_shape",
+) -> None:
+    """Fail at bind time when field and base shapes mismatch.
+
+    Intended for process constructors.
+    
+    If both the field and the base expose a concrete ``event_shape``
+    (the unconditional case), a mismatch raises immediately rather than surviving 
+    until ``sample()``.
+    
+    It is a deliberate no-op when either side is conditional, its shape is not
+    knowable without a context, so lazy/conditional workflows are unaffected.
+    """
+    field_shape = _static_event_shape(field)
+    base_shape = _static_event_shape(base)
+    
+    # no need to check when either side is conditional
+    if field_shape is None or base_shape is None:
+        return
+    
+    # mismatch raises immediately
+    if field_shape != base_shape:
+        msg = f"{message}: field {field_shape} != base {base_shape}"
+        raise ValueError(msg)
 
 
 class TransformedField:

--- a/src/nami/processes/action.py
+++ b/src/nami/processes/action.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import torch
 
+from nami.core.specs import TensorSpec
 from nami.distributions.base import expand_distribution, has_rsample
 from nami.lazy import (
     LazyDistribution,
@@ -35,7 +36,9 @@ from nami.parameterizations import Action, Parameterization
 from nami.processes._common import (
     ProcessRuntimeMixin,
     cast_time,
+    eager_validate_base_event_shape,
     resolve_event_ndim,
+    resolve_event_ndim_override,
     validate_base_event_ndim,
 )
 
@@ -74,7 +77,11 @@ class ActionMatching(LazyProcess):
         Time endpoints for integration.  ``t0=0.0, t1=1.0`` matches the
         flow-matching convention (noise to data).
     event_ndim
-        Optional override for the field's event rank.
+        Optional override for the field's event rank.  Mutually
+        exclusive with ``spec``.
+    spec
+        Optional :class:`TensorSpec` supplying the event rank.
+        Mutually exclusive with ``event_ndim``.
     """
 
     def __init__(
@@ -87,6 +94,7 @@ class ActionMatching(LazyProcess):
         t0: float = 0.0,
         t1: float = 1.0,
         event_ndim: int | None = None,
+        spec: TensorSpec | None = None,
         validate_args: bool = True,
     ):
         super().__init__()
@@ -106,8 +114,11 @@ class ActionMatching(LazyProcess):
         )
         self.t0 = float(t0)
         self.t1 = float(t1)
-        self.event_ndim = event_ndim
+        self.event_ndim = resolve_event_ndim_override(spec, event_ndim)
         self.validate_args = bool(validate_args)
+
+        if self.validate_args:
+            eager_validate_base_event_shape(self.field, self.base)
 
     def forward(self, c: torch.Tensor | None = None) -> ActionMatchingProcess:
         field = self.field(c)
@@ -136,6 +147,7 @@ class ActionMatching(LazyProcess):
             validate_base_event_ndim(
                 base,
                 event_ndim,
+                field_event_shape=getattr(field, "event_shape", None),
                 message="base.event_shape does not match field.event_ndim",
             )
 

--- a/src/nami/processes/consistency.py
+++ b/src/nami/processes/consistency.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import torch
 
+from nami.core.specs import TensorSpec
 from nami.distributions.base import expand_distribution, has_rsample
 from nami.interpolants.linear import velocity_prediction
 from nami.lazy import (
@@ -28,7 +29,9 @@ from nami.parameterizations import Parameterization, Velocity
 from nami.processes._common import (
     ProcessRuntimeMixin,
     cast_time,
+    eager_validate_base_event_shape,
     resolve_event_ndim,
+    resolve_event_ndim_override,
     validate_base_event_ndim,
 )
 from nami.processes.fm import FlowMatchingProcess
@@ -61,7 +64,9 @@ class ConsistencyFlowMatching(LazyProcess):
         t0 (float): Source time, usually the noise endpoint.
         t1 (float): Target time, usually the data endpoint.
         event_ndim (int | None): Event rank fallback when the field does not
-            expose ``event_ndim``.
+            expose ``event_ndim``. Mutually exclusive with ``spec``.
+        spec (TensorSpec | None): Event specification supplying the event
+            rank. Mutually exclusive with ``event_ndim``.
         validate_args (bool): Whether to validate target and event-shape
             compatibility.
     """
@@ -77,6 +82,7 @@ class ConsistencyFlowMatching(LazyProcess):
         t0: float = 0.0,
         t1: float = 1.0,
         event_ndim: int | None = None,
+        spec: TensorSpec | None = None,
         validate_args: bool = True,
     ):
         super().__init__()
@@ -95,8 +101,11 @@ class ConsistencyFlowMatching(LazyProcess):
         self.h_head = h_head
         self.t0 = float(t0)
         self.t1 = float(t1)
-        self.event_ndim = event_ndim
+        self.event_ndim = resolve_event_ndim_override(spec, event_ndim)
         self.validate_args = bool(validate_args)
+
+        if self.validate_args:
+            eager_validate_base_event_shape(self.field, self.base)
 
     def forward(self, c: torch.Tensor | None = None) -> ConsistencyFlowMatchingProcess:
         field = self.field(c)
@@ -126,6 +135,7 @@ class ConsistencyFlowMatching(LazyProcess):
             validate_base_event_ndim(
                 base,
                 event_ndim,
+                field_event_shape=getattr(field, "event_shape", None),
                 message="base.event_shape does not match field.event_ndim",
             )
 

--- a/src/nami/processes/diffusion.py
+++ b/src/nami/processes/diffusion.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import torch
 
+from nami.core.specs import TensorSpec
 from nami.diffusion import (
     eps_to_score,
     expand_like,
@@ -38,7 +39,9 @@ from nami.parameterizations import X0, Epsilon, Parameterization, Score, VPredic
 from nami.processes._common import (
     ProcessRuntimeMixin,
     cast_time,
+    eager_validate_base_event_shape,
     model_device_dtype,
+    resolve_event_shape_override,
     validate_base_event_ndim,
 )
 
@@ -59,7 +62,10 @@ class Diffusion(LazyProcess):
         base (LazyDistribution | torch.distributions.Distribution | None):
             Optional base distribution.
         event_shape (tuple[int, ...] | None): Event shape used when creating a
-            default base distribution.
+            default base distribution. Mutually exclusive with ``spec``.
+        spec (TensorSpec | None): Event specification supplying the event
+            shape, and a dtype for the default base distribution when the
+            model exposes none. Mutually exclusive with ``event_shape``.
         validate_args (bool): Whether to validate target and event-shape
             compatibility.
 
@@ -80,6 +86,7 @@ class Diffusion(LazyProcess):
         t1: float = 0.0,
         base: LazyDistribution | torch.distributions.Distribution | None = None,
         event_shape: tuple[int, ...] | None = None,
+        spec: TensorSpec | None = None,
         validate_args: bool = True,
     ):
         super().__init__()
@@ -96,8 +103,12 @@ class Diffusion(LazyProcess):
             if base is None or isinstance(base, LazyDistribution)
             else UnconditionalDistribution(base)
         )
-        self.event_shape = event_shape
+        self.event_shape = resolve_event_shape_override(spec, event_shape)
+        self._base_dtype = spec.dtype if spec is not None else None
         self.validate_args = bool(validate_args)
+
+        if self.validate_args:
+            eager_validate_base_event_shape(self.model, self.base)
 
     def forward(self, c: torch.Tensor | None = None) -> DiffusionProcess:
         model = self.model(c)
@@ -107,7 +118,13 @@ class Diffusion(LazyProcess):
             if self.event_shape is None:
                 msg = "event_shape is required when base is None"
                 raise ValueError(msg)
+            # TODO: cross-check self.event_shape against model.event_shape here.
+            # The eager bind-time validation only fires when a concrete base is
+            # supplied; in the base=None path the base is built from event_shape,
+            # so a model/event_shape mismatch still slips through to sample().
             device, dtype = model_device_dtype(model)
+            if dtype is None:
+                dtype = self._base_dtype
             batch_shape = tuple(c.shape[:-1]) if c is not None else ()
             base = StandardNormal(
                 self.event_shape, batch_shape=batch_shape, device=device, dtype=dtype
@@ -141,6 +158,7 @@ class Diffusion(LazyProcess):
                 validate_base_event_ndim(
                     base,
                     int(event_ndim),
+                    field_event_shape=getattr(model, "event_shape", None),
                     message="model.event_ndim does not match base.event_shape",
                 )
 

--- a/src/nami/processes/fm.py
+++ b/src/nami/processes/fm.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import torch
 
+from nami.core.specs import TensorSpec
 from nami.distributions.base import expand_distribution, has_rsample
 from nami.fields._common import require_event_ndim
 from nami.interpolants.linear import velocity_prediction
@@ -36,7 +37,9 @@ from nami.processes._common import (
     ProcessRuntimeMixin,
     TransformedField,
     cast_time,
+    eager_validate_base_event_shape,
     resolve_event_ndim,
+    resolve_event_ndim_override,
     validate_base_event_ndim,
 )
 
@@ -53,7 +56,9 @@ class FlowMatching(LazyProcess):
         t0 (float): Initial integration time.
         t1 (float): Final integration time.
         event_ndim (int | None): Event rank fallback when the field does not
-            expose ``event_ndim``.
+            expose ``event_ndim``. Mutually exclusive with ``spec``.
+        spec (TensorSpec | None): Event specification supplying the event
+            rank. Mutually exclusive with ``event_ndim``.
         validate_args (bool): Whether to validate target and event shapes.
 
     Unlike :class:`~nami.processes.diffusion.Diffusion`, FM has no
@@ -91,6 +96,7 @@ class FlowMatching(LazyProcess):
         t0: float = 0.0,
         t1: float = 1.0,
         event_ndim: int | None = None,
+        spec: TensorSpec | None = None,
         validate_args: bool = True,
     ):
         super().__init__()
@@ -108,8 +114,11 @@ class FlowMatching(LazyProcess):
         )
         self.t0 = float(t0)
         self.t1 = float(t1)
-        self.event_ndim = event_ndim
+        self.event_ndim = resolve_event_ndim_override(spec, event_ndim)
         self.validate_args = bool(validate_args)
+
+        if self.validate_args:
+            eager_validate_base_event_shape(self.field, self.base)
 
     def forward(self, c: torch.Tensor | None = None) -> FlowMatchingProcess:
         field = self.field(c)
@@ -139,6 +148,7 @@ class FlowMatching(LazyProcess):
             validate_base_event_ndim(
                 base,
                 event_ndim,
+                field_event_shape=getattr(field, "event_shape", None),
                 message="base.event_shape does not match field.event_ndim",
             )
 

--- a/src/nami/processes/gm.py
+++ b/src/nami/processes/gm.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import torch
 
+from nami.core.specs import TensorSpec
 from nami.distributions.base import expand_distribution, has_rsample
 from nami.distributions.normal import StandardNormal
 from nami.fields._common import require_event_ndim
@@ -27,7 +28,9 @@ from nami.parameterizations import GeneratorParams, Parameterization
 from nami.processes._common import (
     ProcessRuntimeMixin,
     cast_time,
+    eager_validate_base_event_shape,
     model_device_dtype,
+    resolve_event_shape_override,
     validate_base_event_ndim,
 )
 
@@ -46,7 +49,9 @@ class GeneratorMatching(LazyProcess):
             Optional base distribution. If ``None``, a standard normal base is
             constructed from ``event_shape`` or the operator event shape.
         event_shape (tuple[int, ...] | None): Event shape used when creating a
-            default base distribution.
+            default base distribution. Mutually exclusive with ``spec``.
+        spec (TensorSpec | None): Event specification supplying the event
+            shape. Mutually exclusive with ``event_shape``.
         validate_args (bool): Whether to validate target and event-shape
             compatibility.
 
@@ -65,6 +70,7 @@ class GeneratorMatching(LazyProcess):
         t1: float = 1.0,
         base: LazyDistribution | torch.distributions.Distribution | None = None,
         event_shape: tuple[int, ...] | None = None,
+        spec: TensorSpec | None = None,
         validate_args: bool = True,
     ):
         super().__init__()
@@ -80,8 +86,11 @@ class GeneratorMatching(LazyProcess):
             if base is None or isinstance(base, LazyDistribution)
             else UnconditionalDistribution(base)
         )
-        self.event_shape = event_shape
+        self.event_shape = resolve_event_shape_override(spec, event_shape)
         self.validate_args = bool(validate_args)
+
+        if self.validate_args:
+            eager_validate_base_event_shape(self.field, self.base)
 
     @property
     def operator(self):
@@ -151,6 +160,7 @@ class GeneratorMatching(LazyProcess):
             validate_base_event_ndim(
                 base,
                 event_ndim,
+                field_event_shape=getattr(field, "event_shape", None),
                 message="field.event_ndim does not match base.event_shape",
             )
             if tuple(operator.event_shape) != event_shape:

--- a/tests/core/test_specs.py
+++ b/tests/core/test_specs.py
@@ -183,6 +183,23 @@ def test_validate_shapes_ndim_errors(sample_tensor_4d, event_ndim, match):
         validate_shapes(sample_tensor_4d, event_ndim=event_ndim)
 
 
+def test_validate_shapes_accepts_spec(sample_tensor_4d):
+    spec = TensorSpec(event_shape=(4, 5))
+    validate_shapes(sample_tensor_4d, spec, batch_shape=(2, 3))
+
+
+def test_validate_shapes_spec_event_error(sample_tensor_4d):
+    spec = TensorSpec(event_shape=(4, 4))
+    with pytest.raises(ValueError, match="event_shape mismatch"):
+        validate_shapes(sample_tensor_4d, spec)
+
+
+def test_validate_shapes_spec_dtype_error(sample_tensor_4d):
+    spec = TensorSpec(event_shape=(4, 5), dtype=torch.float64)
+    with pytest.raises(TypeError, match="dtype mismatch"):
+        validate_shapes(sample_tensor_4d, spec)
+
+
 # TensorSpec tests
 
 

--- a/tests/fields/test_velocity.py
+++ b/tests/fields/test_velocity.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 from nami import VelocityField
+from nami.core.specs import TensorSpec
 
 
 def test_velocity_field_supports_tuple_event_shape():
@@ -80,3 +81,15 @@ def test_velocity_field_validates_context_leading_shape():
 def test_velocity_field_rejects_negative_condition_dim():
     with pytest.raises(ValueError, match="condition_dim must be non-negative"):
         VelocityField(3, condition_dim=-1, hidden=16, layers=1)
+
+
+def test_velocity_field_exposes_tensor_spec():
+    # The spec is the single source of shape truth; the legacy attributes
+    # must stay consistent with it.
+    field = VelocityField((2, 3), hidden=16, layers=1)
+
+    assert isinstance(field.spec, TensorSpec)
+    assert field.spec.event_shape == (2, 3)
+    assert field.event_shape == (2, 3)
+    assert field.event_ndim == field.spec.event_ndim == 2
+    assert field.flat_dim == field.spec.numel == 6

--- a/tests/generators/test_base_operator.py
+++ b/tests/generators/test_base_operator.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import torch
 
+from nami.core.specs import TensorSpec
 from nami.generators.base import GeneratorOperator
+from nami.generators.ctmc import CTMCGeneratorOperator
+from nami.generators.operators import ItoGeneratorOperator
 from nami.losses.bregman import SquaredL2
 
 
@@ -26,3 +29,16 @@ def test_base_default_divergence_is_squared_l2():
     """A Euclidean operator defaults to squared-L2 (MSE)."""
     op = _MinimalOperator()
     assert isinstance(op.default_divergence(), SquaredL2)
+
+
+def test_operators_expose_consistent_tensor_spec():
+    """``spec`` is the single source of shape truth for operators."""
+    ito = ItoGeneratorOperator((2, 3), diffusion="diagonal")
+    assert isinstance(ito.spec, TensorSpec)
+    assert ito.spec.event_shape == ito.event_shape == (2, 3)
+    assert ito.spec.event_ndim == ito.event_ndim == 2
+
+    ctmc = CTMCGeneratorOperator(5, (4,))
+    assert isinstance(ctmc.spec, TensorSpec)
+    assert ctmc.spec.event_shape == ctmc.event_shape == (4,)
+    assert ctmc.parameter_shape == (4, 5)

--- a/tests/processes/test_common.py
+++ b/tests/processes/test_common.py
@@ -15,6 +15,7 @@ import pytest
 import torch
 
 from nami import StandardNormal
+from nami.core.specs import TensorSpec
 from nami.processes import (
     ConsistencyFlowMatchingProcess,
     DiffusionProcess,
@@ -25,9 +26,12 @@ from nami.processes._common import (
     ProcessRuntimeMixin,
     TransformedField,
     cast_time,
+    eager_validate_base_event_shape,
     expand_context,
     model_device_dtype,
     resolve_event_ndim,
+    resolve_event_ndim_override,
+    resolve_event_shape_override,
     validate_base_event_ndim,
 )
 
@@ -109,6 +113,25 @@ def test_validate_base_event_ndim_rejects_mismatch() -> None:
         validate_base_event_ndim(base, 2)
 
 
+def test_validate_base_event_ndim_rejects_full_shape_mismatch() -> None:
+    # Same rank (1), different concrete shape: rank-only would pass, the
+    # full-shape check must reject.
+    base = StandardNormal(event_shape=(4,))
+    validate_base_event_ndim(base, 1, field_event_shape=(4,))
+    with pytest.raises(ValueError, match=r"\(8,\) != base event_shape \(4,\)"):
+        validate_base_event_ndim(base, 1, field_event_shape=(8,))
+
+
+def test_eager_validate_base_event_shape_noop_when_shape_unknown() -> None:
+    # A field exposing only event_ndim (no concrete event_shape) cannot be
+    # checked at bind time; the helper must stay silent rather than guess.
+    class _RankOnlyField:
+        event_ndim = 1
+
+    eager_validate_base_event_shape(_RankOnlyField(), StandardNormal(event_shape=(4,)))
+    eager_validate_base_event_shape(_RankOnlyField(), None)
+
+
 # ---------------------------------------------------------------------------
 # TransformedField adapter
 
@@ -167,3 +190,29 @@ def test_runtime_mixin_expand_context_dispatches_to_pure_helper() -> None:
     expected = expand_context(c, target, event_ndim=1)
     actual = proc._expand_context(c, target)
     assert torch.equal(actual, expected)
+
+
+# ---------------------------------------------------------------------------
+# resolve_event_ndim_override / resolve_event_shape_override
+
+
+def test_resolve_event_ndim_override_prefers_spec() -> None:
+    assert resolve_event_ndim_override(TensorSpec((2, 3)), None) == 2
+    assert resolve_event_ndim_override(None, 1) == 1
+    assert resolve_event_ndim_override(None, None) is None
+
+
+def test_resolve_event_ndim_override_rejects_both() -> None:
+    with pytest.raises(ValueError, match="not both"):
+        resolve_event_ndim_override(TensorSpec((2,)), 1)
+
+
+def test_resolve_event_shape_override_prefers_spec() -> None:
+    assert resolve_event_shape_override(TensorSpec((2, 3)), None) == (2, 3)
+    assert resolve_event_shape_override(None, (4,)) == (4,)
+    assert resolve_event_shape_override(None, None) is None
+
+
+def test_resolve_event_shape_override_rejects_both() -> None:
+    with pytest.raises(ValueError, match="not both"):
+        resolve_event_shape_override(TensorSpec((2,)), (2,))

--- a/tests/test_flow_matching.py
+++ b/tests/test_flow_matching.py
@@ -14,7 +14,9 @@ from nami import (
     Velocity,
     velocity_prediction,
 )
+from nami.core.specs import TensorSpec
 from nami.fields.base import VectorField
+from nami.fields.velocity import VelocityField
 from nami.lazy import LazyDistribution, LazyProcess, UnconditionalDistribution
 
 
@@ -36,6 +38,29 @@ class BaseVectorField(VectorField):
     def forward(self, x, t, c=None):
         _ = t, c
         return x
+
+
+def test_construction_rejects_field_base_event_shape_mismatch():
+    # A concrete field/base shape mismatch must fail fast at construction,
+    # not survive until sample().  Both have event_ndim == 1, so a rank-only
+    # check would let this through.
+    with pytest.raises(ValueError, match=r"event_shape"):
+        FlowMatching(
+            VelocityField(8),
+            StandardNormal(event_shape=(4,)),
+            RK4(steps=2),
+        )
+
+
+def test_construction_allows_matching_event_shape():
+    # Matching shapes construct cleanly; validate_args=False bypasses the check.
+    FlowMatching(VelocityField(8), StandardNormal(event_shape=(8,)), RK4(steps=2))
+    FlowMatching(
+        VelocityField(8),
+        StandardNormal(event_shape=(4,)),
+        RK4(steps=2),
+        validate_args=False,
+    )
 
 
 def test_log_prob_without_divergence_path_raises_clean_error():
@@ -330,3 +355,23 @@ def test_legacy_string_parameterization_kwarg_does_not_exist():
 
     with pytest.raises(TypeError, match="Parameterization"):
         process()
+
+
+def test_construction_accepts_spec_for_event_ndim():
+    # A TensorSpec can stand in for the explicit event_ndim fallback.
+    fm = FlowMatching(
+        PlainField(),
+        StandardNormal(event_shape=(4,)),
+        RK4(steps=2),
+        spec=TensorSpec((4,)),
+    )
+    assert fm.event_ndim == 1
+
+    with pytest.raises(ValueError, match="not both"):
+        FlowMatching(
+            PlainField(),
+            StandardNormal(event_shape=(4,)),
+            RK4(steps=2),
+            event_ndim=1,
+            spec=TensorSpec((4,)),
+        )

--- a/tests/test_normal_distributions.py
+++ b/tests/test_normal_distributions.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import pytest
 import torch
 from torch.distributions import Independent, Normal
 
+from nami.core.specs import TensorSpec
+from nami.distributions.mask import AllMask
 from nami.distributions.normal import DiagonalNormal, StandardNormal
 
 
@@ -40,3 +43,41 @@ def test_diagonal_normal_sample_rsample_log_prob_and_expand() -> None:
     assert expanded.batch_shape == torch.Size([3, 2])
     assert expanded.event_shape == torch.Size([2])
     assert expanded.sample().shape == (3, 2, 2)
+
+
+def test_standard_normal_accepts_spec() -> None:
+    dist = StandardNormal(spec=TensorSpec((2, 3), dtype=torch.float64))
+
+    assert dist.event_shape == torch.Size([2, 3])
+    assert dist.sample().dtype == torch.float64
+    assert dist.spec.event_shape == (2, 3)
+
+
+def test_standard_normal_rejects_spec_with_explicit_args() -> None:
+    with pytest.raises(ValueError, match="not both"):
+        StandardNormal((2,), spec=TensorSpec((2,)))
+    with pytest.raises(ValueError, match="not both"):
+        StandardNormal(spec=TensorSpec((2,)), dtype=torch.float64)
+    with pytest.raises(ValueError, match="required"):
+        StandardNormal()
+
+
+def test_diagonal_normal_spec_survives_expand() -> None:
+    loc = torch.zeros(2, 3)
+    dist = DiagonalNormal(loc=loc, scale=torch.ones(2, 3), event_ndim=1)
+
+    assert dist.spec.event_shape == (3,)
+    assert dist.event_ndim == 1
+
+    expanded = dist.expand(torch.Size([5, 2]))
+    assert expanded.event_ndim == 1
+    assert expanded.spec.event_shape == (3,)
+
+
+def test_all_mask_accepts_spec() -> None:
+    dist = AllMask(spec=TensorSpec((4,)), mask_index=5)
+
+    assert dist.sample().shape == (4,)
+    assert (dist.sample() == 5).all()
+    with pytest.raises(ValueError, match="not both"):
+        AllMask((4,), spec=TensorSpec((4,)), mask_index=5)


### PR DESCRIPTION
### Description

This PR adds better guards against a shape mismatch at bind time when the field exposes a concrete shape. All call sites have been updated to use the new guard in the different process constructors. Further to this, the `TensorSpec` is now being consistently used in the library for the shape source across fields and distributions. Some more updates to the documentation regarding the core abstractions has been done, including a better description of the expected tensor layout in nami along with an easy to read example.