### PR TITLE
feat: pmatching implementations and CTSM methods [1/2]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__
 dist/
 src/nami/_version.py
 books/external/
+books/experiment/pm/figures/
 
 # below is taken from https://github.com/scientific-python/cookie/tree/main, but may simplify this
 # Byte-compiled / optimized / DLL files

--- a/docs/api/fields.rst
+++ b/docs/api/fields.rst
@@ -12,5 +12,6 @@ Fields
    composite
    consistency
    generator
+   scalar_potential
    transformer_velocity
    velocity

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -13,8 +13,10 @@ API Reference
    generators
    interpolants
    losses
+   paths
    processes
    schedules
+   scores
    solvers
    misc
    toys

--- a/docs/api/losses.rst
+++ b/docs/api/losses.rst
@@ -12,5 +12,7 @@ Losses
    cgm
    consistency
    log_density
+   parameter_flow
    regression
+   score_matching
    stochastic_fm

--- a/docs/api/paths.rst
+++ b/docs/api/paths.rst
@@ -1,7 +1,9 @@
-:orphan:
-
 Paths
 =====
 
-The legacy ``nami.paths`` package has been replaced by
-:mod:`nami.interpolants`. See :doc:`interpolants` for the current API.
+.. currentmodule:: nami.paths
+
+.. autosummary::
+   :toctree: _generated
+
+   parameter

--- a/docs/api/processes.rst
+++ b/docs/api/processes.rst
@@ -11,3 +11,4 @@ Processes
    diffusion
    fm
    gm
+   parameter_flow

--- a/docs/api/scores.rst
+++ b/docs/api/scores.rst
@@ -1,0 +1,12 @@
+Scores
+======
+
+.. currentmodule:: nami.scores
+
+.. autosummary::
+   :toctree: _generated
+
+   ctsm
+   dsm
+   mined
+   oracle

--- a/src/nami/__init__.py
+++ b/src/nami/__init__.py
@@ -22,6 +22,7 @@ from nami.fields.composite import (
 from nami.fields.consistency import LogDensityHead
 from nami.fields.ctmc import CTMCField
 from nami.fields.generator import GeneratorField
+from nami.fields.scalar_potential import ScalarPotentialField
 from nami.fields.transformer_velocity import TransformerVelocityField
 from nami.fields.velocity import VelocityField
 from nami.generators.base import GeneratorOperator
@@ -59,7 +60,16 @@ from nami.losses.bregman import (
 from nami.losses.cgm import cgm_loss
 from nami.losses.consistency import consistency_loss
 from nami.losses.log_density import log_density_consistency_loss
+from nami.losses.parameter_flow import (
+    parameter_flow_loss,
+    path_pinned_parameter_flow_loss,
+)
 from nami.losses.regression import regression_loss
+from nami.losses.score_matching import (
+    ctsm_loss,
+    denoising_score_matching_loss,
+    time_score_matching_loss,
+)
 from nami.losses.stochastic_fm import stochastic_fm_loss
 from nami.parameterizations import (
     X0,
@@ -71,14 +81,20 @@ from nami.parameterizations import (
     Velocity,
     VPrediction,
 )
+from nami.paths.parameter import FisherRaoGeodesicPath, LinearParameterPath
 from nami.processes.action import ActionMatching
 from nami.processes.consistency import ConsistencyFlowMatching
 from nami.processes.diffusion import Diffusion
 from nami.processes.fm import FlowMatching
 from nami.processes.gm import GeneratorMatching
+from nami.processes.parameter_flow import ParameterFlow
 from nami.schedules.edm import EDMSchedule
 from nami.schedules.ve import VESchedule
 from nami.schedules.vp import VPSchedule
+from nami.scores.ctsm import CTSMJointScore
+from nami.scores.dsm import DSMSpatialScore
+from nami.scores.mined import MinedJointScore
+from nami.scores.oracle import OracleScore
 from nami.solvers.dpm import DPMSolverPP
 from nami.solvers.heun import Heun
 from nami.solvers.jump import TauLeapingSampler
@@ -103,6 +119,7 @@ __all__ = [  # noqa: RUF022  (deliberately grouped by layer, not alphabetised)
     "GeneratorField",
     "CTMCField",
     "ActionHead",
+    "ScalarPotentialField",  # parameter-flow potential (v = grad phi)
     "DriftFromVelocityScore",
     "MarkovizationDriftFromVelocityScore",
     # Base distributions (source / t=0) for the process
@@ -146,6 +163,11 @@ __all__ = [  # noqa: RUF022  (deliberately grouped by layer, not alphabetised)
     "log_density_consistency_loss",
     "cgm_loss",  # conditional generator matching
     "action_matching_loss",
+    "parameter_flow_loss",  # parameter-flow elliptic-PDE residual (dim theta == 1)
+    "path_pinned_parameter_flow_loss",  # multi-theta, path-locked (DC2 option b)
+    "ctsm_loss",  # full CTSM objective (Yu 2025 Eq. 8), trains time-score nets
+    "denoising_score_matching_loss",  # trains DSM spatial-score nets
+    "time_score_matching_loss",  # trains CTSM time-score nets
     # Bregman divergences (loss geometry for generator matching)
     "BregmanDivergence",
     "KLDivergence",
@@ -157,6 +179,15 @@ __all__ = [  # noqa: RUF022  (deliberately grouped by layer, not alphabetised)
     "ConsistencyFlowMatching",
     "GeneratorMatching",  # generator matching
     "ActionMatching",
+    "ParameterFlow",  # parameter-flow transport (theta_0 -> theta_1)
+    # Parameter-space paths (bind-time context for ParameterFlow)
+    "LinearParameterPath",
+    "FisherRaoGeodesicPath",
+    # Score estimators (frozen targets for parameter_flow_loss)
+    "OracleScore",
+    "MinedJointScore",
+    "CTSMJointScore",  # trained time-score net -> joint score
+    "DSMSpatialScore",  # trained DSM net -> spatial score
     # Solvers: numerical schemes for the process
     "RK4",  # solver to use for ODEs
     "Heun",  # second-order solver to use for ODEs

--- a/src/nami/diagnostics.py
+++ b/src/nami/diagnostics.py
@@ -103,6 +103,53 @@ def divergence_stats(
     }
 
 
+def score_projection(
+    process,
+    x: torch.Tensor,
+    theta: torch.Tensor,
+    *,
+    estimator=None,
+) -> torch.Tensor:
+    r"""Score projection ``\nabla_\theta \log \hat p_\theta(x)`` via autograd.
+
+    Differentiates the process's change-of-variables ``log_prob`` with
+    respect to the conditioning variable, using the ``c=`` override so
+    ``theta`` enters as an autograd leaf rather than bind-time context.
+
+    The per-sample gradient is recovered from a single ``autograd.grad``
+    call on the summed log-prob because ``\log p_{\theta_i}(x_i)`` does
+    not depend on ``\theta_j`` for ``i != j``.
+
+    Parameters
+    ----------
+    process
+        A bound runtime process (e.g.
+        :class:`~nami.processes.fm.FlowMatchingProcess`) whose
+        ``log_prob`` accepts ``c=`` and ``estimator=``.
+    x
+        Evaluation points, shape ``(*lead, *event_shape)``.
+    theta
+        Conditioning values, shape ``(*lead, d_theta)``.  Detached and
+        cloned internally; the caller's tensor is not mutated.
+    estimator
+        Optional divergence estimator forwarded to ``log_prob``.  Must
+        be constructed with ``create_graph=True`` (e.g.
+        ``ExactDivergence(create_graph=True)``) — otherwise the
+        divergence term of the change-of-variables integral is detached
+        from ``theta`` and the projection is silently wrong.
+
+    Returns
+    -------
+    Tensor, shape ``(*lead, d_theta)``
+        ``\nabla_\theta \log \hat p_\theta(x)``.
+    """
+    theta = theta.detach().clone().requires_grad_(True)
+    with torch.enable_grad():
+        logp = process.log_prob(x, c=theta, estimator=estimator)
+        (grad_theta,) = torch.autograd.grad(logp.sum(), theta)
+    return grad_theta
+
+
 def reversibility_error(
     field,
     solver,

--- a/src/nami/fields/__init__.py
+++ b/src/nami/fields/__init__.py
@@ -19,6 +19,7 @@ from nami.fields.composite import (
 from nami.fields.consistency import LogDensityHead
 from nami.fields.ctmc import CTMCField
 from nami.fields.generator import GeneratorField
+from nami.fields.scalar_potential import ScalarPotentialField
 from nami.fields.transformer_velocity import TransformerVelocityField
 from nami.fields.velocity import VelocityField
 
@@ -30,6 +31,7 @@ __all__ = [
     "GeneratorField",
     "LogDensityHead",
     "MarkovizationDriftFromVelocityScore",
+    "ScalarPotentialField",
     "TransformerVelocityField",
     "TwoHeadField",
     "VelocityField",

--- a/src/nami/fields/consistency.py
+++ b/src/nami/fields/consistency.py
@@ -1,3 +1,5 @@
+r"""Scalar head that predicts :math:`\\log p_t(x_t)`."""
+
 from __future__ import annotations
 
 import torch

--- a/src/nami/fields/scalar_potential.py
+++ b/src/nami/fields/scalar_potential.py
@@ -1,0 +1,223 @@
+r"""Scalar-potential field :math:`\phi(x, \theta)` for parameter-flow.
+
+The curl-free gauge realisation is that the transport velocity is the
+spatial gradient :math:`v = \nabla_x \phi`.  The scalar-potential field follows the
+:math:`v = \nabla\phi` ansatz, which is the Otto-horizontal representative in the
+:math:`\mathrm{Diff}(M)/\mathrm{Diff}_\mu(M)` bundle. It is what makes
+parameter-flow transport a Wasserstein geodesic.
+
+Follows the ``(x, t, c)`` calling convention of
+:class:`~nami.fields.action.ActionHead` with ``t`` accepted-and-ignored
+(:math:`\phi` depends on position and parameter only; the path
+parameter ``s`` enters through :math:`\theta(s)`) and ``c`` carrying
+:math:`\theta`.
+
+The training loss's Laplacian :math:`\Delta_x\phi` is the same
+operator as the runtime ``log_prob`` divergence
+(:math:`\nabla\!\cdot v = \nabla\!\cdot\nabla\phi = \Delta\phi`), with
+the identical cost structure.  :meth:`velocity_field`
+exposes the gradient as a field-shaped object so both consume one
+:mod:`nami.divergence` estimator instead of bespoke double-autograd
+helpers.
+
+TODO: add any useful refs.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from nami.components import MLPBackbone
+from nami.core.specs import TensorSpec, flatten_event, validate_shapes
+from nami.fields._common import normalise_event_shape, validate_context
+
+
+class ScalarPotentialField(nn.Module):
+    r"""Scalar potential :math:`\phi(x, \theta) \to \mathbb{R}` per sample.
+
+    Structurally a sibling of :class:`~nami.fields.action.ActionHead`
+    (scalar-out MLP head, velocity recovered by autograd), but without a
+    time embedding: parameter-flow's "time" is the path parameter ``s``,
+    which reaches :math:`\phi` only through :math:`\theta(s)`.
+
+    TODO: any embeddings needed for theta?
+
+    Parameters
+    ----------
+    dim : int or tuple[int, ...]
+        Data dimensionality (event shape).
+    theta_dim : int
+        Parameter dimensionality (last axis of ``theta``).  Must be
+        positive — :math:`\phi(x, \theta)` is meaningless without
+        :math:`\theta`.
+    hidden : int
+        Hidden layer width.
+    layers : int
+        Number of hidden layers.
+    activation : str
+        Activation function.
+    dropout : float
+        Dropout probability.
+    layer_norm : bool
+        Whether to apply layer normalisation.
+    """
+
+    def __init__(
+        self,
+        dim: int | tuple[int, ...],
+        *,
+        theta_dim: int,
+        hidden: int = 128,
+        layers: int = 4,
+        activation: str = "silu",
+        dropout: float = 0.0,
+        layer_norm: bool = False,
+    ):
+        super().__init__()
+        if theta_dim <= 0:
+            msg = f"theta_dim must be positive, got {theta_dim}"
+            raise ValueError(msg)
+
+        self.spec = TensorSpec(normalise_event_shape(dim))
+        self.theta_dim = int(theta_dim)
+        self.backbone = MLPBackbone(
+            self.flat_dim + self.theta_dim,
+            1,  # scalar output
+            hidden=hidden,
+            layers=layers,
+            activation=activation,
+            dropout=dropout,
+            layer_norm=layer_norm,
+        )
+
+    @property
+    def event_shape(self) -> tuple[int, ...]:
+        return self.spec.event_shape
+
+    @property
+    def event_ndim(self) -> int:
+        return self.spec.event_ndim
+
+    @property
+    def flat_dim(self) -> int:
+        return self.spec.numel
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        t: torch.Tensor | None = None,
+        c: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        r"""Evaluate the scalar potential :math:`\phi(x, \theta)`.
+
+        ``t`` is accepted for ``(x, t, c)`` convention compatibility and
+        ignored; ``c`` carries :math:`\theta`.
+
+        Returns
+        -------
+        Tensor, shape ``(*lead,)``
+            Scalar potential per sample.  Its gradient w.r.t. ``x`` is
+            the parameter-flow transport velocity.
+        """
+        del t
+        validate_shapes(x, self.spec)
+        x_flat = flatten_event(x, self.event_ndim)
+        lead_shape = tuple(x_flat.shape[:-1])
+        validate_context(c, self.theta_dim, lead_shape)
+        assert c is not None  # narrowed by validate_context (theta_dim > 0)
+        inputs = torch.cat([x_flat, c], dim=-1)
+        return self.backbone(inputs).squeeze(-1)
+
+    def velocity(
+        self,
+        x: torch.Tensor,
+        theta: torch.Tensor,
+        *,
+        create_graph: bool = True,
+    ) -> torch.Tensor:
+        r"""Recover the velocity :math:`\nabla_x \phi(x, \theta)` by autograd.
+
+        :math:`\phi` is a scalar per sample; summing across the batch
+        lets a single ``autograd.grad`` call return the per-sample
+        gradient because :math:`\phi_i` does not depend on ``x_j`` for
+        ``i != j``.  Always runs under ``torch.enable_grad()`` so it
+        works inside ``torch.no_grad()`` sampling loops.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Evaluation points, shape ``(*lead, *event_shape)``.
+        theta : torch.Tensor
+            Parameters, shape ``(*lead, theta_dim)``.
+        create_graph : bool
+            Build a graph through the gradient so second-order
+            objectives (the parameter-flow loss, ``loss.backward()``)
+            reach :math:`\phi`'s parameters.  Set ``False`` for
+            eval-only transport to save memory.
+        """
+        with torch.enable_grad():
+            if create_graph:
+                xx = x if x.requires_grad else x.clone().requires_grad_(True)
+            else:
+                xx = x.detach().requires_grad_(True)
+            phi = self(xx, None, theta)
+            (grad_phi,) = torch.autograd.grad(
+                outputs=phi.sum(),
+                inputs=xx,
+                create_graph=create_graph,
+            )
+        return grad_phi
+
+    def velocity_field(self) -> _GradientField:
+        r"""Expose :math:`\nabla_x \phi` as a field-shaped object.
+
+        The returned adapter follows the ``(x, t, c)`` convention and
+        ``event_ndim``/``spec`` protocol, so :mod:`nami.divergence`
+        estimators applied to it compute
+        :math:`\nabla\!\cdot\nabla\phi = \Delta_x\phi`. The single
+        shared operator is used by both the parameter-flow loss (its
+        Laplacian term) and the runtime log-density divergence.
+
+        The adapter always builds the inner autograd graph
+        (``create_graph=True`` on the gradient): its sole purpose is to
+        be differentiated again by a divergence estimator, which is
+        impossible against a detached gradient.  Whether the resulting
+        Laplacian itself carries a graph (for training) is the
+        *estimator's* ``create_graph`` flag.
+        """
+        return _GradientField(self)
+
+
+class _GradientField:
+    """Adapter presenting ``\\nabla_x phi`` as a ``(x, t, c)`` field.
+
+    Private adapter class, not to be exposed.
+    """
+
+    def __init__(self, potential: ScalarPotentialField):
+        self._potential = potential
+
+    @property
+    def spec(self) -> TensorSpec:
+        return self._potential.spec
+
+    @property
+    def event_ndim(self) -> int:
+        return self._potential.event_ndim
+
+    @property
+    def event_shape(self) -> tuple[int, ...]:
+        return self._potential.event_shape
+
+    def __call__(
+        self,
+        x: torch.Tensor,
+        t: torch.Tensor | None = None,
+        c: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        del t
+        if c is None:
+            msg = "gradient-field evaluation requires theta as the context c"
+            raise ValueError(msg)
+        return self._potential.velocity(x, c, create_graph=True)

--- a/src/nami/losses/__init__.py
+++ b/src/nami/losses/__init__.py
@@ -27,7 +27,16 @@ from nami.losses.bridge import bridge_matching_loss
 from nami.losses.cgm import cgm_loss
 from nami.losses.consistency import consistency_loss
 from nami.losses.log_density import log_density_consistency_loss
+from nami.losses.parameter_flow import (
+    parameter_flow_loss,
+    path_pinned_parameter_flow_loss,
+)
 from nami.losses.regression import regression_loss
+from nami.losses.score_matching import (
+    ctsm_loss,
+    denoising_score_matching_loss,
+    time_score_matching_loss,
+)
 from nami.losses.stochastic_fm import stochastic_fm_loss
 
 __all__ = [
@@ -40,7 +49,12 @@ __all__ = [
     "bridge_matching_loss",
     "cgm_loss",
     "consistency_loss",
+    "ctsm_loss",
+    "denoising_score_matching_loss",
     "log_density_consistency_loss",
+    "parameter_flow_loss",
+    "path_pinned_parameter_flow_loss",
     "regression_loss",
     "stochastic_fm_loss",
+    "time_score_matching_loss",
 ]

--- a/src/nami/losses/parameter_flow.py
+++ b/src/nami/losses/parameter_flow.py
@@ -1,0 +1,316 @@
+r"""Elliptic-PDE residual loss for parameter-flow training.
+
+Trains a scalar potential :math:`\phi(x, \theta)` so that its gradient
+flow transports :math:`p_{\theta_0} \to p_{\theta_1}` along a path in
+parameter space.  The objective is the squared residual of the
+continuity equation in elliptic form:
+
+.. math::
+
+    \mathcal{L}(\phi) = \mathbb{E}_{p_\theta(x),\, p(\theta)} \Bigl[
+        \bigl( \partial_\theta \log p_\theta(x)
+               + \Delta_x \phi(x, \theta)
+               + \nabla_x \phi(x, \theta) \cdot \nabla_x \log p_\theta(x)
+        \bigr)^2
+    \Bigr]
+
+The two scores are fixed regression targets supplied by
+:class:`~nami.scores.base.ScoreEstimator` objects. This loss does not
+train them; they are upstream objects (closed-form oracles, mined simulator
+scores, or separately-trained networks).
+
+The Laplacian :math:`\Delta_x\phi` is computed as the divergence of the
+potential's gradient field
+(:meth:`~nami.fields.scalar_potential.ScalarPotentialField.velocity_field`),
+so the loss and the runtime log-density divergence share one
+:mod:`nami.divergence` estimator.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from nami.divergence import ExactDivergence
+from nami.losses._common import leading_shape, reduce_loss, require_event_ndim
+
+
+def parameter_flow_loss(
+    field,
+    *,
+    x: torch.Tensor,
+    theta: torch.Tensor,
+    joint_score,
+    spatial_score,
+    divergence_estimator=None,
+    reduction: str = "mean",
+    create_graph: bool = True,
+) -> torch.Tensor:
+    r"""Squared residual of the parameter-flow continuity PDE.
+
+    Parameters
+    ----------
+    field
+        Scalar potential with the
+        :class:`~nami.fields.scalar_potential.ScalarPotentialField`
+        surface: ``(x, t, c) -> (*lead,)`` plus ``velocity`` /
+        ``velocity_field`` helpers and ``event_ndim``.
+    x
+        Samples from :math:`p_\theta`, shape ``(*lead, *event_shape)``.
+    theta
+        Matching parameters, shape ``(*lead, d_theta)``.
+    joint_score
+        Estimator for :math:`\partial_\theta \log p_\theta(x)`,
+        returning ``(*lead, d_theta)``.  Consumed under ``no_grad`` —
+        a frozen target.
+    spatial_score
+        Estimator for :math:`\nabla_x \log p_\theta(x)`, returning
+        ``(*lead, d_x)``.  Also a frozen target.
+    divergence_estimator
+        Estimator applied to the potential's gradient field to obtain
+        :math:`\Delta_x\phi`.  Defaults to
+        ``ExactDivergence(create_graph=create_graph)``.  When supplying
+        your own for training, construct it with ``create_graph=True``
+        or ``loss.backward()`` will not reach the Laplacian term.
+    reduction
+        ``"mean"`` | ``"sum"`` | ``"none"``.
+    create_graph
+        Build the second-order graph so ``loss.backward()`` reaches
+        :math:`\phi`'s parameters.  Set ``False`` only for eval-time
+        residual monitoring.
+
+    Notes
+    -----
+    This is the ``dim(theta) == 1`` loss: :math:`\phi` is the
+    *per-unit-*:math:`\theta` potential, and the matching transport scales
+    the velocity by :math:`\dot\theta` (see
+    :meth:`~nami.processes.parameter_flow.ParameterFlowProcess.transport`).
+    For multi-:math:`\theta` use the path-pinned loss,
+    :func:`path_pinned_parameter_flow_loss`, where :math:`\phi` is the
+    per-unit-``s`` potential and transport carries no :math:`\dot\theta` scaling.
+    """
+    event_ndim = require_event_ndim(field)
+    if event_ndim != 1:
+        msg = (
+            "parameter_flow_loss currently supports event_ndim == 1 "
+            f"(flat event vectors); got {event_ndim}"
+        )
+        raise ValueError(msg)
+    lead = leading_shape(x, event_ndim)
+
+    if theta.shape[-1] != 1:
+        # A single scalar potential cannot represent transport along a
+        # vector theta. The velocity must be linear in theta-dot, which
+        # requires one component potential per theta direction and
+        # reintroduces Frobenius compatibility between them.
+        msg = (
+            "parameter_flow_loss supports dim(theta) == 1; got "
+            f"theta_dim={theta.shape[-1]}.  Multi-theta parameter-flow "
+            "requires per-component potentials with Frobenius compatibility."
+        )
+        raise ValueError(msg)
+
+    if divergence_estimator is None:
+        divergence_estimator = ExactDivergence(create_graph=create_graph)
+
+    x = x.detach()
+
+    grad_phi = field.velocity(x, theta, create_graph=create_graph)
+    # The potential ignores t; a dummy scalar keeps the (x, t, c) estimator convention intact.
+    t_dummy = torch.zeros((), device=x.device, dtype=x.dtype)
+    lap_phi = divergence_estimator(field.velocity_field(), x, t_dummy, theta)
+
+    with torch.no_grad():
+        dlogp_dtheta = joint_score(x, theta)
+        grad_logp = spatial_score(x, theta)
+
+    if dlogp_dtheta.shape != theta.shape:
+        msg = (
+            f"joint_score returned shape {tuple(dlogp_dtheta.shape)}; "
+            f"expected theta's shape {tuple(theta.shape)}"
+        )
+        raise ValueError(msg)
+    if grad_logp.shape != grad_phi.shape:
+        msg = (
+            f"spatial_score returned shape {tuple(grad_logp.shape)}; "
+            f"expected x's shape {tuple(grad_phi.shape)}"
+        )
+        raise ValueError(msg)
+
+    residual = (
+        dlogp_dtheta
+        + lap_phi.unsqueeze(-1)
+        + (grad_phi * grad_logp).sum(dim=-1, keepdim=True)
+    )
+
+    loss_per_sample = residual.pow(2).sum(dim=-1)
+    assert loss_per_sample.shape == lead
+    return reduce_loss(loss_per_sample, reduction)
+
+
+def path_pinned_parameter_flow_loss(
+    field,
+    *,
+    x: torch.Tensor,
+    s: torch.Tensor,
+    path,
+    joint_score,
+    spatial_score,
+    directional_score: bool = False,
+    divergence_estimator=None,
+    reduction: str = "mean",
+    create_graph: bool = True,
+) -> torch.Tensor:
+    r"""Squared residual of the parameter-flow PDE pinned to one path.
+
+    Multi-:math:`\theta` transport is realised as a single scalar potential
+    trained for one fixed :class:`~nami.paths.parameter.ParameterPath`.
+    The continuity equation is projected onto the path's tangent :math:`\dot\theta(s)`, collapsing the
+    :math:`d_\theta`-component vector PDE to one scalar equation in the path parameter ``s``:
+
+    .. math::
+
+        \mathcal{L}(\phi) = \mathbb{E}_{s,\, p_{\theta(s)}(x)} \Bigl[
+            \bigl( \dot\theta(s)\cdot\partial_\theta\log p_{\theta(s)}(x)
+                   + \Delta_x \phi(x, \theta(s))
+                   + \nabla_x \phi(x, \theta(s)) \cdot
+                     \nabla_x \log p_{\theta(s)}(x)
+            \bigr)^2
+        \Bigr]
+
+    where :math:`\dot\theta(s)\cdot\partial_\theta\log p` is the directional
+    (along-path) derivative :math:`\tfrac{d}{ds}\log p_{\theta(s)}(x)`, a
+    scalar per sample, formed by contracting the joint score against the
+    path tangent.
+
+    Convention difference vs :func:`parameter_flow_loss`
+    ----------------------------------------------------
+    The two losses define :math:`\phi` with different units, and the
+    transport that consumes the trained field must match:
+
+    - :func:`parameter_flow_loss` (``dim(theta) == 1``): :math:`\phi` is the
+      per-unit-:math:`\theta` potential.  Transport integrates
+      :math:`\dot x = \dot\theta\,\nabla_x\phi`, i.e. the velocity is
+      scaled by :math:`\dot\theta`.
+
+    - this loss (path-pinned, any :math:`d_\theta`): :math:`\phi` is the
+      per-unit-``s`` potential, the path tangent :math:`\dot\theta(s)`
+      is already baked into the residual.  Transport integrates
+      :math:`\dot x = \nabla_x\phi(x, \theta(s))` directly, with no
+      :math:`\dot\theta` multiplication.  Use
+      :class:`~nami.processes.parameter_flow.ParameterFlowProcess` bound to
+      the same path. A path with ``d_theta > 1`` selects pinned mode automatically.
+
+    The trained :math:`\phi` is therefore path-locked: it is valid only
+    for transport along the path it was trained on.
+
+    Parameters
+    ----------
+    field: ScalarPotentialField
+        Scalar potential with the
+        :class:`~nami.fields.scalar_potential.ScalarPotentialField`
+        surface, conditioned on :math:`\theta(s)` (so ``theta_dim ==
+        d_theta``).
+    x: torch.Tensor
+        Samples from :math:`p_{\theta(s)}`, shape ``(*lead, *event_shape)``.
+    s: torch.Tensor
+        Path parameters, shape ``(*lead,)`` — one scalar ``s`` per sample.
+    path: ParameterPath
+        The fixed :class:`~nami.paths.parameter.ParameterPath`.  Its
+        :math:`\theta(s)` conditions :math:`\phi` and its
+        :math:`\dot\theta(s)` projects the joint score.
+    joint_score: ScoreEstimator
+        Estimator for :math:`\partial_\theta\log p_\theta(x)`, returning
+        ``(*lead, d_theta)``.  Contracted with :math:`\dot\theta(s)` to the
+        directional derivative.  Consumed under ``no_grad``.  With
+        ``directional_score=True`` it instead returns the already-contracted
+        along-path derivative :math:`\tfrac{d}{ds}\log p`.
+    spatial_score: ScoreEstimator
+        Estimator for :math:`\nabla_x\log p_\theta(x)`, returning
+        ``(*lead, d_x)``.  Frozen target.
+    directional_score: bool
+        Treat ``joint_score(x, theta)`` as the scalar along-path derivative
+        :math:`\tfrac{d}{ds}\log p`, shape ``(*lead,)`` or ``(*lead, 1)``,
+        and skip the :math:`\dot\theta(s)` contraction.  This is the shape
+        produced by
+        :class:`~nami.scores.ctsm.CTSMJointScore` with ``directional=True``.
+    divergence_estimator: DivergenceEstimator
+        Estimator for :math:`\Delta_x\phi`.  Defaults to
+        ``ExactDivergence(create_graph=create_graph)``.
+    reduction: str
+        ``"mean"`` | ``"sum"`` | ``"none"``.
+    create_graph: bool
+        Build the second-order graph so ``loss.backward()`` reaches
+        :math:`\phi`'s parameters.
+    """
+    event_ndim = require_event_ndim(field)
+    if event_ndim != 1:
+        msg = (
+            "path_pinned_parameter_flow_loss currently supports event_ndim "
+            f"== 1 (flat event vectors); got {event_ndim}"
+        )
+        raise ValueError(msg)
+    lead = leading_shape(x, event_ndim)
+
+    if tuple(s.shape) != lead:
+        msg = f"s must have the leading shape of x {tuple(lead)}; got {tuple(s.shape)}"
+        raise ValueError(msg)
+
+    theta = path.theta(s)
+    dtheta = path.dtheta_ds(s)
+    if theta.shape != dtheta.shape:
+        msg = (
+            "path.theta(s) and path.dtheta_ds(s) must share a shape; got "
+            f"{tuple(theta.shape)} and {tuple(dtheta.shape)}"
+        )
+        raise ValueError(msg)
+
+    if divergence_estimator is None:
+        divergence_estimator = ExactDivergence(create_graph=create_graph)
+
+    x = x.detach()
+
+    grad_phi = field.velocity(x, theta, create_graph=create_graph)
+    t_dummy = torch.zeros((), device=x.device, dtype=x.dtype)
+    lap_phi = divergence_estimator(field.velocity_field(), x, t_dummy, theta)
+
+    with torch.no_grad():
+        dlogp_dtheta = joint_score(x, theta)
+        grad_logp = spatial_score(x, theta)
+
+    if grad_logp.shape != grad_phi.shape:
+        msg = (
+            f"spatial_score returned shape {tuple(grad_logp.shape)}; "
+            f"expected x's shape {tuple(grad_phi.shape)}"
+        )
+        raise ValueError(msg)
+
+    if directional_score:
+        # joint_score already returns the along-path derivative d/ds log p;
+        # use it directly with no tangent contraction.
+        if dlogp_dtheta.shape == lead:
+            directional = dlogp_dtheta
+        elif dlogp_dtheta.shape == (*lead, 1):
+            directional = dlogp_dtheta.squeeze(-1)
+        else:
+            msg = (
+                "directional joint_score must return shape "
+                f"{tuple(lead)} or {(*lead, 1)}; got "
+                f"{tuple(dlogp_dtheta.shape)}"
+            )
+            raise ValueError(msg)
+    else:
+        if dlogp_dtheta.shape != theta.shape:
+            msg = (
+                f"joint_score returned shape {tuple(dlogp_dtheta.shape)}; "
+                f"expected theta's shape {tuple(theta.shape)}"
+            )
+            raise ValueError(msg)
+        # project the joint score onto the path tangent to form the
+        # directional (along-path) derivative d/ds log p, a scalar per sample.
+        directional = (dtheta * dlogp_dtheta).sum(dim=-1)
+
+    residual = directional + lap_phi + (grad_phi * grad_logp).sum(dim=-1)
+
+    loss_per_sample = residual.pow(2)
+    assert loss_per_sample.shape == lead
+    return reduce_loss(loss_per_sample, reduction)

--- a/src/nami/losses/score_matching.py
+++ b/src/nami/losses/score_matching.py
@@ -1,0 +1,339 @@
+r"""Training losses for the upstream score networks of parameter-flow.
+
+The parameter-flow loss
+(:func:`~nami.losses.parameter_flow.parameter_flow_loss` /
+:func:`~nami.losses.parameter_flow.path_pinned_parameter_flow_loss`)
+consumes two frozen score targets
+
+- a joint score :math:`\partial_\theta\log p_\theta(x)` and
+- a spatial score :math:`\nabla_x\log p_\theta(x)`.
+
+When those are not closed-form oracles they are supplied by trained score networks
+(:class:`~nami.scores.ctsm.CTSMJointScore`,
+:class:`~nami.scores.dsm.DSMSpatialScore`).
+This module trains the score networks.
+
+Three losses:
+
+- :func:`denoising_score_matching_loss`: standard Gaussian DSM (Vincent
+  2011) for the **spatial** score :math:`\nabla_x\log p_\theta(x)`,
+  amortised over :math:`\theta`.
+
+- :func:`ctsm_loss`: the full Conditional Time Score Matching
+  objective (Yu et al. 2025, Eq. 8): self-contained training of the
+  time score :math:`\partial_t\log p_t(x)` along a Gaussian conditional
+  path :math:`p_t(x|z) = \mathcal{N}(\alpha_t z, \sigma_t^2 I)`, no
+  density knowledge required. Theorem 1 guarantees the minimiser is
+  the marginal time score.
+
+- :func:`time_score_matching_loss`: the general Theorem-3 regression
+  against a caller-supplied per-sample target (conditional or
+  marginal).
+
+References
+----------
+- Yu, Klami, Hyvärinen, Korba, Chehab, *Density Ratio Estimation with
+  Conditional Probability Paths*, ICML 2025 (arXiv:2502.02300).
+- Choi et al., *Density Ratio Estimation via Infinitesimal
+  Classification*, 2022: the integrated time-score identity
+  :math:`\log[p_1(x)/p_0(x)] = \int_0^1 \partial_t\log p_t(x)\,dt`.
+- Vincent, *A Connection Between Score Matching and Denoising
+  Autoencoders*, 2011.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from nami.losses._common import (
+    leading_shape,
+    reduce_loss,
+    require_event_ndim,
+    sample_t,
+)
+
+
+def denoising_score_matching_loss(
+    net,
+    *,
+    x: torch.Tensor,
+    theta: torch.Tensor,
+    sigma: float | torch.Tensor,
+    noise: torch.Tensor | None = None,
+    reduction: str = "mean",
+) -> torch.Tensor:
+    r"""Denoising score-matching loss conditioned on theta.
+
+    Corrupts clean samples with isotropic Gaussian noise of scale
+    :math:`\sigma` and regresses the network onto the denoising target,
+    which is the (negative) score of the Gaussian corruption kernel:
+
+    .. math::
+
+        \mathcal{L} = \mathbb{E}_{x, \tilde x}\,
+            \bigl\| \mathrm{net}(\tilde x, \theta)
+                    - \tfrac{x - \tilde x}{\sigma^2} \bigr\|^2,
+        \qquad \tilde x = x + \sigma\,\varepsilon,\ \varepsilon\sim N(0, I).
+
+    At the optimum :math:`\mathrm{net}(\cdot, \theta) =
+    \nabla_x\log p^\sigma_\theta` (the score of the sigma-smoothed
+    density); for small :math:`\sigma` this approximates
+    :math:`\nabla_x\log p_\theta`.  The trained network is wrapped by
+    :class:`~nami.scores.dsm.DSMSpatialScore`.
+
+    Parameters
+    ----------
+    net: nn.Module
+        Network ``(x_tilde, theta) -> Tensor`` returning the estimated
+        spatial score, shape ``(*lead, d_x)``.
+    x: torch.Tensor
+        Clean samples from :math:`p_\theta`, shape ``(*lead, *event)``.
+    theta: torch.Tensor
+        Conditioning parameters, shape ``(*lead, d_theta)``.
+    sigma: float | torch.Tensor
+        Noise scale.  A python float for a single scale, or a tensor
+        broadcastable to ``x`` for a per-sample range (sample it in the
+        caller and pass it in).
+    noise: torch.Tensor | None
+        Optional pre-drawn standard-normal noise of ``x``'s shape; drawn
+        internally when ``None`` (the usual path).
+    reduction: str
+        ``"mean"`` | ``"sum"`` | ``"none"``.
+    """
+    event_ndim = require_event_ndim(net) if hasattr(net, "event_ndim") else 1
+    lead = leading_shape(x, event_ndim)
+
+    sigma_t = torch.as_tensor(sigma, device=x.device, dtype=x.dtype)
+    if noise is None:
+        noise = torch.randn_like(x)
+    x_tilde = x + sigma_t * noise
+    # the denoising target
+    target = (x - x_tilde) / sigma_t.pow(2)
+
+    pred = net(x_tilde, theta)
+    if pred.shape != target.shape:
+        msg = (
+            f"net returned shape {tuple(pred.shape)}; expected x's shape "
+            f"{tuple(target.shape)}"
+        )
+        raise ValueError(msg)
+
+    per_sample = (pred - target).pow(2).reshape(*lead, -1).sum(dim=-1)
+    return reduce_loss(per_sample, reduction)
+
+
+def _schedule_rates(
+    schedule, t: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    r"""Evaluate ``\alpha, \sigma, \dot\alpha, \dot\sigma`` at ``t``.
+
+    Derivatives come from autograd through the schedule, so any
+    :class:`~nami.schedules.base.NoiseSchedule` works without exposing
+    derivative methods, or in other words, the CTSM construction is path-agnostic.
+    """
+    with torch.enable_grad():
+        t_req = t.detach().requires_grad_(True)
+        a = schedule.alpha(t_req)
+        s = schedule.sigma(t_req)
+        (a_dot,) = torch.autograd.grad(a.sum(), t_req, retain_graph=True)
+        (s_dot,) = torch.autograd.grad(s.sum(), t_req)
+    return a.detach(), s.detach(), a_dot, s_dot
+
+
+def _conditional_time_score(
+    z_flat: torch.Tensor,
+    eps_flat: torch.Tensor,
+    a_dot: torch.Tensor,
+    s: torch.Tensor,
+    s_dot: torch.Tensor,
+) -> torch.Tensor:
+    r"""Closed-form ``\partial_t \log p_t(x_t|z)`` on the Gaussian path.
+
+    With :math:`x_t = \alpha_t z + \sigma_t\varepsilon` and
+    :math:`p_t(x|z) = \mathcal{N}(\alpha_t z, \sigma_t^2 I)` (Yu et al.
+    2025, Eq. 14), substituting :math:`x_t - \alpha_t z = \sigma_t
+    \varepsilon` into :math:`\partial_t` of the Gaussian log-density
+    gives (Eqs. 15-16):
+
+    .. math::
+
+        \partial_t \log p_t(x_t|z)
+        = \frac{\dot\alpha_t}{\sigma_t}\,(\varepsilon\cdot z)
+        + \frac{\dot\sigma_t}{\sigma_t}\,(\lVert\varepsilon\rVert^2 - d).
+    """
+    d = eps_flat.shape[-1]
+    dot_ez = (eps_flat * z_flat).sum(dim=-1)
+    eps_sq = eps_flat.pow(2).sum(dim=-1)
+    return (a_dot / s) * dot_ez + (s_dot / s) * (eps_sq - d)
+
+
+def ctsm_loss(
+    net,
+    *,
+    x_data: torch.Tensor,
+    t: torch.Tensor | None = None,
+    schedule,
+    eps_t: float = 1e-3,
+    noise: torch.Tensor | None = None,
+    weighting="normalised",
+    reduction: str = "mean",
+) -> torch.Tensor:
+    r"""Conditional Time Score Matching loss.
+
+    Trains a time-score network :math:`s_\phi(x, t) \approx
+    \partial_t\log p_t(x)` along the Gaussian conditional path
+
+    .. math::
+
+        x_t = \alpha_t z + \sigma_t\,\varepsilon,
+        \qquad z \sim p_{\mathrm{data}},\ \varepsilon \sim \mathcal{N}(0, I),
+
+    by regressing against the conditional time score
+    :math:`\partial_t\log p_t(x_t|z)`, which is closed-form (see
+    :func:`_conditional_time_score`). No knowledge of the marginal
+    density is needed.  This is the denoising trick applied to time
+    scores: by Yu et al.'s Theorem 1 the objective equals the
+    intractable marginal (TSM) objective up to an additive constant, so
+    the minimiser is the marginal time score
+    :math:`\partial_t\log p_t(x) = \mathbb{E}[\partial_t\log p_t(x|z)
+    \mid x_t = x]`.
+
+    The trained network supports the integrated density-ratio identity
+    (Choi et al. 2022) :math:`\log[p_{t_1}(x)/p_{t_0}(x)] =
+    \int_{t_0}^{t_1} s_\phi(x, \tau)\,d\tau` and is the natural training
+    surface for :class:`~nami.scores.ctsm.CTSMJointScore` when the
+    interpolation variable is identified with a parameter path
+    coordinate.  Note the identification caveat: this objective trains
+    time scores along the schedule's noise path; using it for a
+    parameter path requires the path marginals to admit the same
+    Gaussian conditional structure.
+
+    Parameters
+    ----------
+    net: nn.Module
+        Time-score network ``(x, t) -> (*lead,)`` or ``(*lead, 1)``.
+    x_data: torch.Tensor
+        Samples ``z`` from the data distribution, shape
+        ``(*lead, *event)``.  These are the conditioning variables
+        (``z = x_1`` in the paper's Eq. 14).
+    t: torch.Tensor | None
+        Optional pre-sampled times.  When ``None``, drawn from
+        ``U[eps_t, 1 - eps_t]``.
+    schedule: NoiseSchedule
+        :class:`~nami.schedules.base.NoiseSchedule` supplying
+        ``alpha(t)`` / ``sigma(t)``; derivatives are taken by autograd,
+        so any schedule works (VP is the paper's default).
+    eps_t
+        Endpoint protection for the automatic ``t`` draw, the target
+        variance diverges where :math:`\sigma_t \to 0`.
+    noise: torch.Tensor | None
+        Optional pre-drawn standard-normal ``\varepsilon`` of
+        ``x_data``'s shape; drawn internally when ``None``.
+    weighting: str | Callable[[torch.Tensor], torch.Tensor]
+        ``"normalised"`` (default) applies the time-score normalisation
+        of Eq. 20, :math:`\lambda(t) \propto 1/\mathbb{E}[(\partial_t
+        \log p_t(x|z))^2]`, in the closed form
+        :math:`\lambda(t)^{-1} = (\dot\alpha_t/\sigma_t)^2\,
+        \mathbb{E}\lVert z\rVert^2 + 2d\,(\dot\sigma_t/\sigma_t)^2`
+        (cross term vanishes by symmetry; :math:`\mathbb{E}\lVert
+        z\rVert^2` estimated from the batch).  ``"uniform"`` disables
+        it; a callable ``t -> weight`` supplies a custom schedule.
+    reduction: str
+        ``"mean"`` | ``"sum"`` | ``"none"``.
+    """
+    event_ndim = require_event_ndim(net) if hasattr(net, "event_ndim") else 1
+    lead = leading_shape(x_data, event_ndim)
+    t = sample_t(x_data, lead, t, eps_t)
+
+    a, s, a_dot, s_dot = _schedule_rates(schedule, t)
+
+    if noise is None:
+        noise = torch.randn_like(x_data)
+    shape = (*lead, *([1] * event_ndim))
+    x_t = a.reshape(shape) * x_data + s.reshape(shape) * noise
+
+    z_flat = x_data.reshape(*lead, -1)
+    eps_flat = noise.reshape(*lead, -1)
+    target = _conditional_time_score(z_flat, eps_flat, a_dot, s, s_dot)
+
+    pred = net(x_t, t)
+    if pred.shape[-1:] == (1,) and pred.ndim == len(lead) + 1:
+        pred = pred.squeeze(-1)
+    if pred.shape != target.shape:
+        msg = (
+            f"net output (squeezed) shape {tuple(pred.shape)} does not match "
+            f"target shape {tuple(target.shape)}"
+        )
+        raise ValueError(msg)
+
+    if weighting == "normalised":
+        d = eps_flat.shape[-1]
+        m2 = z_flat.pow(2).sum(dim=-1).mean().detach()
+        lam = 1.0 / ((a_dot / s).pow(2) * m2 + 2 * d * (s_dot / s).pow(2))
+    elif weighting == "uniform":
+        lam = torch.ones_like(target)
+    elif callable(weighting):
+        lam = weighting(t)
+        if lam.shape != target.shape:
+            lam = lam.expand_as(target)
+    else:
+        msg = "weighting must be 'normalised', 'uniform', or a callable"
+        raise ValueError(msg)
+
+    per_sample = lam.detach() * (pred - target).pow(2)
+    return reduce_loss(per_sample, reduction)
+
+
+def time_score_matching_loss(
+    net,
+    *,
+    x: torch.Tensor,
+    s: torch.Tensor,
+    target: torch.Tensor,
+    reduction: str = "mean",
+) -> torch.Tensor:
+    r"""Time score-matching loss.
+
+    Regresses a time-score network ``net(x, s)`` onto
+    :math:`\tfrac{d}{ds}\log p_{\theta(s)}(x)`, the derivative of the
+    log-density along a :class:`~nami.paths.parameter.ParameterPath`.
+
+    A plain regression against a caller-supplied per-sample target, which
+    may be either the marginal time score (analytic toys) or any
+    tractable conditional whose posterior mean is the marginal. The
+    theorem guarantees the two objectives share a minimiser. Use this
+    when the target comes from outside (closed forms, instrumented
+    simulators). For the self-contained case, training from samples
+    alone along a Gaussian conditional path, no density knowledge, use
+    :func:`ctsm_loss`.
+
+    Parameters
+    ----------
+    net: nn.Module
+        Time-score network ``(x, s) -> Tensor`` of shape ``(*lead, 1)``
+        (or ``(*lead,)``; squeezed-compatible with ``target``).
+    x: torch.Tensor
+        Samples from :math:`p_{\theta(s)}`, shape ``(*lead, *event)``.
+    s: torch.Tensor
+        Path parameters, shape ``(*lead,)`` or ``(*lead, 1)``.
+    target: torch.Tensor
+        The per-sample regression target
+        :math:`\tfrac{d}{ds}\log p_{\theta(s)}(x)`, broadcastable to the
+        network output.
+    reduction: str
+        ``"mean"`` | ``"sum"`` | ``"none"``.
+    """
+    pred = net(x, s)
+    if pred.shape[-1:] == (1,):
+        pred = pred.squeeze(-1)
+    tgt = target
+    if tgt.shape[-1:] == (1,):
+        tgt = tgt.squeeze(-1)
+    if pred.shape != tgt.shape:
+        msg = (
+            f"net output (squeezed) shape {tuple(pred.shape)} does not match "
+            f"target (squeezed) shape {tuple(tgt.shape)}"
+        )
+        raise ValueError(msg)
+    per_sample = (pred - tgt).pow(2)
+    return reduce_loss(per_sample, reduction)

--- a/src/nami/losses/score_matching.py
+++ b/src/nami/losses/score_matching.py
@@ -91,9 +91,10 @@ def denoising_score_matching_loss(
     theta: torch.Tensor
         Conditioning parameters, shape ``(*lead, d_theta)``.
     sigma: float | torch.Tensor
-        Noise scale.  A python float for a single scale, or a tensor
-        broadcastable to ``x`` for a per-sample range (sample it in the
-        caller and pass it in).
+        Noise scale.  A python float for a single scale, a per-sample
+        tensor of shape ``lead`` (one scale per sample — reshaped here to
+        broadcast over the event dims), or a tensor already broadcastable
+        to ``x``.  Sample any range in the caller and pass it in.
     noise: torch.Tensor | None
         Optional pre-drawn standard-normal noise of ``x``'s shape; drawn
         internally when ``None`` (the usual path).
@@ -104,6 +105,9 @@ def denoising_score_matching_loss(
     lead = leading_shape(x, event_ndim)
 
     sigma_t = torch.as_tensor(sigma, device=x.device, dtype=x.dtype)
+    # promote per-sample sigma to broadcastable shape (*lead, 1, 1)
+    if tuple(sigma_t.shape) == lead and event_ndim:
+        sigma_t = sigma_t.reshape(*lead, *([1] * event_ndim))
     if noise is None:
         noise = torch.randn_like(x)
     x_tilde = x + sigma_t * noise

--- a/src/nami/paths/__init__.py
+++ b/src/nami/paths/__init__.py
@@ -1,0 +1,15 @@
+"""Parameter-space paths"""
+
+from __future__ import annotations
+
+from nami.paths.parameter import (
+    FisherRaoGeodesicPath,
+    LinearParameterPath,
+    ParameterPath,
+)
+
+__all__ = [
+    "FisherRaoGeodesicPath",
+    "LinearParameterPath",
+    "ParameterPath",
+]

--- a/src/nami/paths/parameter.py
+++ b/src/nami/paths/parameter.py
@@ -1,0 +1,80 @@
+r"""Parameter-space paths :math:`\theta: [0, 1] \to \Theta`.
+
+Encodes the curve along which parameter-flow transports samples.
+
+Distinct from :class:`~nami.interpolants.protocol.Interpolant`: an
+Interpolant parameterises a path in distribution space (base
+:math:`\to` data); a ``ParameterPath`` parameterises a path in
+parameter space (:math:`\theta_0 \to \theta_1`). They compose: a
+parameter-flow sample at endpoint :math:`\theta_1` is obtained by
+drawing from :math:`p_{\theta_0}` and integrating the velocity along
+the ``ParameterPath``.
+
+For ``dim(Theta) = 1`` every smooth path is trivially compatible.  For
+``dim(Theta) >= 2`` the path choice is not so simple. The Euclidean
+line is the default but the geometric ideal is a Fisher-Rao geodesic
+in :math:`(\Theta, I(\theta))`.
+
+TODO: Fisher-Rao geodesic path implementation.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+import torch
+
+
+@runtime_checkable
+class ParameterPath(Protocol):
+    r"""Protocol for parameter-space paths."""
+
+    def theta(self, s: torch.Tensor) -> torch.Tensor:
+        r"""Evaluate :math:`\theta(s)`."""
+        ...
+
+    def dtheta_ds(self, s: torch.Tensor) -> torch.Tensor:
+        r"""Evaluate the path velocity :math:`\dot\theta(s)`."""
+        ...
+
+
+class LinearParameterPath:
+    r"""Euclidean line: :math:`\theta(s) = (1 - s)\theta_0 + s\theta_1`.
+
+    Parameters
+    ----------
+    theta_0, theta_1
+        Path endpoints of identical shape ``(d_theta,)`` (or any common
+        shape).  ``theta(s)`` / ``dtheta_ds(s)`` broadcast a ``(lead,)``
+        path parameter to ``(lead, theta_0.shape)``.
+    """
+
+    def __init__(self, theta_0: torch.Tensor, theta_1: torch.Tensor):
+        if theta_0.shape != theta_1.shape:
+            msg = (
+                "theta_0 and theta_1 must share a shape; got "
+                f"{tuple(theta_0.shape)} and {tuple(theta_1.shape)}"
+            )
+            raise ValueError(msg)
+        self.theta_0 = theta_0
+        self.theta_1 = theta_1
+
+    def _expand_s(self, s: torch.Tensor) -> torch.Tensor:
+        return s.reshape(*s.shape, *([1] * self.theta_0.ndim))
+
+    def theta(self, s: torch.Tensor) -> torch.Tensor:
+        s_ = self._expand_s(s)
+        theta_0 = self.theta_0.to(s)
+        theta_1 = self.theta_1.to(s)
+        return (1 - s_) * theta_0 + s_ * theta_1
+
+    def dtheta_ds(self, s: torch.Tensor) -> torch.Tensor:
+        delta = (self.theta_1 - self.theta_0).to(s)
+        return delta.expand(*s.shape, *delta.shape)
+
+
+class FisherRaoGeodesicPath:
+    r""":math:`\theta(s)` as the exp-map geodesic in :math:`(\Theta, I(\theta))`.
+
+    information-geometric path. [STUB]
+    """

--- a/src/nami/processes/__init__.py
+++ b/src/nami/processes/__init__.py
@@ -18,6 +18,7 @@ from nami.processes.consistency import (
 from nami.processes.diffusion import Diffusion, DiffusionProcess
 from nami.processes.fm import FlowMatching, FlowMatchingProcess
 from nami.processes.gm import GeneratorMatching, GeneratorMatchingProcess
+from nami.processes.parameter_flow import ParameterFlow, ParameterFlowProcess
 
 __all__ = [
     "ActionMatching",
@@ -30,4 +31,6 @@ __all__ = [
     "FlowMatchingProcess",
     "GeneratorMatching",
     "GeneratorMatchingProcess",
+    "ParameterFlow",
+    "ParameterFlowProcess",
 ]

--- a/src/nami/processes/fm.py
+++ b/src/nami/processes/fm.py
@@ -377,7 +377,9 @@ class FlowMatchingProcess(ProcessRuntimeMixin):
             estimator=estimator,
         )
 
-    def log_prob(self, x: torch.Tensor, *, estimator=None) -> torch.Tensor:
+    def log_prob(
+        self, x: torch.Tensor, *, c: torch.Tensor | None = None, estimator=None
+    ) -> torch.Tensor:
         """Evaluate log-density via change of variables.
 
         Callers should usually pass ``estimator=...`` unless the field
@@ -385,11 +387,18 @@ class FlowMatchingProcess(ProcessRuntimeMixin):
         divergence estimator here because the tradeoff is model-dependent:
         exact traces are deterministic but can be expensive, while
         Hutchinson-style estimators scale better but add stochasticity.
+
+        ``c`` overrides the bind-time context for this evaluation only.
+        This lets conditioning variables enter as *function arguments* —
+        autograd leaves — so gradients like ``\\nabla_c \\log p_c(x)`` (e.g.
+        the score projection in
+        :func:`~nami.diagnostics.score_projection`) can be taken without
+        re-binding the process.
         """
         event_ndim = require_event_ndim(self._field)
         lead = x.shape[:-event_ndim] if event_ndim else x.shape
         logp0 = torch.zeros(lead, device=x.device, dtype=x.dtype)
-        context = self._expand_context(self._context, x)
+        context = self._expand_context(c if c is not None else self._context, x)
 
         def f_aug(xi, t):
             tt = cast_time(t, xi)

--- a/src/nami/processes/parameter_flow.py
+++ b/src/nami/processes/parameter_flow.py
@@ -1,0 +1,314 @@
+r"""Continuity-equation flow on x-space with parameter-space path-time.
+
+Transports samples from :math:`p_{\theta_0}` to :math:`p_{\theta_1}`
+by integrating :math:`\dot x = \dot\theta(s)\,\nabla_x\phi(x, \theta(s))`
+from ``s = 0`` to ``s = 1`` along a chosen
+:class:`~nami.paths.parameter.ParameterPath`.
+
+Sibling of :class:`~nami.processes.fm.FlowMatching`, not subclass.  The
+time semantics differ (``s`` parameterises :math:`\theta_0 \to
+\theta_1` in parameter space, not base :math:`\to` data in distribution
+space); the field is a scalar potential whose gradient is the velocity
+(the curl-free Otto-horizontal gauge. See
+:class:`~nami.fields.scalar_potential.ScalarPotentialField`); and
+samples entering at ``s = 0`` come from a *user-provided*
+:math:`p_{\theta_0}` (a flow model trained at :math:`\theta_0`, or an
+analytic toy), not a learned base, so no ``base`` argument and no
+``sample()``.
+
+Runtime only; the training surface lives in
+:func:`~nami.losses.parameter_flow.parameter_flow_loss`.
+
+The :math:`\dot\theta` multiplication happens *here*, not in the field:
+:math:`\phi` is a potential, and for ``dim(theta) == 1`` (the supported
+case) the transport velocity along the path is the scalar
+:math:`\dot\theta(s)` times :math:`\nabla_x\phi`.  A vector
+:math:`\theta` would need one component potential per direction plus a
+Frobenius-compatibility treatment. Currently out of scope.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from nami.divergence import ExactDivergence
+from nami.lazy import LazyProcess
+from nami.processes._common import ProcessRuntimeMixin, cast_time
+
+
+class ParameterFlow(LazyProcess):
+    r"""Lazy parameter-flow process: binds a path at call time.
+
+    A single trained potential serves multi-endpoint workflows — bind a
+    new :class:`~nami.paths.parameter.ParameterPath` per
+    :math:`\theta_0 \to \theta_1` pair without re-instantiation.
+
+    Unlike other ``LazyProcess`` subclasses, ``forward`` binds a
+    *parameter path* rather than a context tensor ``c`` — the path is
+    the parameter-flow analogue of bind-time conditioning.
+
+    Parameters
+    ----------
+    field: ScalarPotentialField
+        Scalar potential with the
+        :class:`~nami.fields.scalar_potential.ScalarPotentialField`
+        surface (``velocity`` / ``velocity_field`` helpers,
+        ``event_shape``).
+    solver: ODESolver
+        ODE solver (any that :class:`~nami.FlowMatching` accepts).
+    s0: float
+        Path-parameter start.
+    s1: float
+        Path-parameter end. ``s0 -> s1`` transports
+        :math:`p_{\theta_0} \to p_{\theta_1}`.
+    """
+
+    def __init__(self, field, solver, *, s0: float = 0.0, s1: float = 1.0):
+        super().__init__()
+        self.field = field
+        self.solver = solver
+        self.s0 = float(s0)
+        self.s1 = float(s1)
+
+    def forward(self, c=None) -> ParameterFlowProcess:
+        """Bind a :class:`~nami.paths.parameter.ParameterPath`.
+
+        The parameter is named ``c`` to honour the ``LazyProcess``
+        contract, but the bound context here is a *path*, not a
+        tensor: ``process = ParameterFlow(field, solver)(path)``.
+        """
+        path = c
+        if path is None:
+            msg = "ParameterFlow requires a ParameterPath to bind"
+            raise ValueError(msg)
+        return ParameterFlowProcess(
+            field=self.field,
+            solver=self.solver,
+            path=path,
+            s0=self.s0,
+            s1=self.s1,
+        )
+
+
+class ParameterFlowProcess(ProcessRuntimeMixin):
+    """One bound parameter path: transport, log-prob delta, score supply."""
+
+    def __init__(self, field, solver, *, path, s0: float, s1: float):
+        self._field = field
+        self._solver = solver
+        self._path = path
+        self._s0 = float(s0)
+        self._s1 = float(s1)
+
+    @property
+    def field(self):
+        return self._field
+
+    @property
+    def path(self):
+        return self._path
+
+    @property
+    def event_shape(self) -> tuple[int, ...]:
+        return tuple(self._field.event_shape)
+
+    def _integrate(self, f, x0: torch.Tensor, *, t0: float, t1: float):
+        kwargs = {}
+        if getattr(self._solver, "requires_steps", False):
+            steps = getattr(self._solver, "steps", None)
+            if steps is None:
+                msg = "solver requires steps"
+                raise ValueError(msg)
+            kwargs["steps"] = steps
+        return self._solver.integrate(f, x0, t0=t0, t1=t1, **kwargs)
+
+    @property
+    def pinned(self) -> bool:
+        r"""Whether transport runs in *path-pinned* (multi-:math:`\theta`) mode.
+
+        ``True`` when the bound path has :math:`d_\theta > 1`.  In pinned
+        mode the field must have been trained with
+        :func:`~nami.losses.parameter_flow.path_pinned_parameter_flow_loss`
+        **on this exact path** (the trained :math:`\phi` is path-locked):
+        :math:`\phi` is the per-unit-``s`` potential, so transport
+        integrates :math:`\dot x = \nabla_x\phi(x, \theta(s))` with **no**
+        :math:`\dot\theta` scaling.  In the ``d_theta == 1`` case
+        (``pinned == False``) :math:`\phi` is the per-unit-:math:`\theta`
+        potential and the velocity is scaled by :math:`\dot\theta`.
+        """
+        probe = torch.zeros(1, dtype=torch.float32)
+        return self._path.dtheta_ds(probe).shape[-1] != 1
+
+    def _path_at(self, s, like: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        lead = like.shape[: like.ndim - len(self.event_shape)]
+        s_ = cast_time(s, like).expand(lead)
+        theta = self._path.theta(s_)
+        dtheta = self._path.dtheta_ds(s_)
+        return theta, dtheta
+
+    def transport(self, x_at_theta0: torch.Tensor) -> torch.Tensor:
+        r"""Transport samples from :math:`p_{\theta_0}` to :math:`p_{\theta_1}`.
+
+        For ``dim(theta) == 1`` integrates :math:`\dot x =
+        \dot\theta(s)\,\nabla_x\phi(x, \theta(s))` from ``s0`` to ``s1``.
+        For a path with ``dim(theta) > 1`` (path-pinned mode, see
+        :attr:`pinned`) the field is the per-unit-``s`` potential and
+        transport integrates :math:`\dot x = \nabla_x\phi(x, \theta(s))`
+        directly without :math:`\dot\theta` scaling.  The field must then
+        have been trained with
+        :func:`~nami.losses.parameter_flow.path_pinned_parameter_flow_loss`
+        on this exact path (path-locked).
+        """
+        pinned = self.pinned
+
+        def f(xi, s):
+            theta, dtheta = self._path_at(s, xi)
+            v = self._field.velocity(xi, theta, create_graph=False)
+            return v if pinned else v * dtheta
+
+        return self._integrate(f, x_at_theta0, t0=self._s0, t1=self._s1)
+
+    def transport_with_logp(
+        self,
+        x_at_theta0: torch.Tensor,
+        log_p_at_theta0: torch.Tensor,
+        *,
+        divergence_estimator,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        r"""Transport with the instantaneous change-of-variables delta.
+
+        The transported log-density is computable but not controlled in
+        KL. The PDE residual loss bounds a Fisher divergence along the path, 
+        not the KL of the endpoint, so the returned log-density carries no 
+        accuracy guarantee even at zero training loss. This is only meant as
+        a diagnostic.
+
+        Parameters
+        ----------
+        x_at_theta0: torch.Tensor
+            Samples from :math:`p_{\theta_0}`, shape ``(*lead, *event_shape)``.
+        log_p_at_theta0: torch.Tensor
+            Log-density of ``x_at_theta0`` under :math:`p_{\theta_0}`, shape ``(*lead,)``.
+            Samples and their log-density under :math:`p_{\theta_0}`.
+        divergence_estimator: DivergenceEstimator
+            Estimator applied to the potential's gradient field. In the
+            ``dim(theta) == 1`` case the divergence of the transport
+            velocity is :math:`\dot\theta\,\Delta_x\phi`; in path-pinned
+            mode (see :attr:`pinned`) it is :math:`\Delta_x\phi` with no
+            :math:`\dot\theta` scaling, the same operator the matching
+            training loss uses.
+        """
+        grad_field = self._field.velocity_field()
+        pinned = self.pinned
+
+        def f_aug(xi, s):
+            theta, dtheta = self._path_at(s, xi)
+            v = self._field.velocity(xi, theta, create_graph=False)
+            # The potential ignores t; a dummy scalar keeps the
+            # (x, t, c) estimator convention intact.
+            t_dummy = torch.zeros((), device=xi.device, dtype=xi.dtype)
+            lap = divergence_estimator(grad_field, xi, t_dummy, theta)
+            if pinned:
+                return v, -lap
+            div = lap * dtheta.squeeze(-1)
+            return v * dtheta, -div
+
+        kwargs = {}
+        if getattr(self._solver, "requires_steps", False):
+            kwargs["steps"] = self._solver.steps
+        return self._solver.integrate_augmented(
+            f_aug,
+            x_at_theta0,
+            log_p_at_theta0,
+            t0=self._s0,
+            t1=self._s1,
+            **kwargs,
+        )
+
+    def score_supply(
+        self,
+        x: torch.Tensor,
+        theta: torch.Tensor | None = None,
+        *,
+        s: torch.Tensor | None = None,
+        spatial_score,
+        divergence_estimator=None,
+    ) -> torch.Tensor:
+        r"""Joint score :math:`\partial_\theta \log \hat p_\theta(x)` from the trained potential.
+
+        Inverts the parameter-flow PDE at evaluation points:
+
+        .. math::
+
+            \partial_\theta \log \hat p_\theta(x)
+            = -\Delta_x\phi(x, \theta)
+              - \nabla_x\phi(x, \theta) \cdot \nabla_x \log p_\theta(x)
+
+        Recovering the joint score from a trained :math:`\phi` is **not**
+        autograd through :math:`\phi` alone — the PDE couples it to the
+        spatial score :math:`\nabla_x \log p_\theta` *at evaluation
+        time*, hence the required ``spatial_score`` estimator.
+
+        Path-pinned mode (:attr:`pinned`, ``dim(theta) > 1``)
+        -----------------------------------------------------
+        A path-pinned :math:`\phi` knows the density only along its
+        training path, so the **full** :math:`d_\theta`-vector joint score
+        is *not* recoverable from it.  What the pinned PDE yields is the
+        **directional** (along-path) score
+        :math:`\dot\theta(s)\cdot\partial_\theta\log\hat p_{\theta(s)}(x)
+        = \tfrac{d}{ds}\log\hat p_{\theta(s)}(x)`, a scalar per sample,
+        returned with shape ``(*lead, 1)``. It is exactly the information the pinned
+        residual constrains.  ``theta`` is ignored in pinned mode
+        such that the path supplies :math:`\theta(s)` from the evaluation ``s``;
+        instead pass ``s`` of shape ``(*lead,)`` via the ``s`` argument.
+
+        Parameters
+        ----------
+        x: torch.Tensor
+            Evaluation points, shape ``(*lead, *event_shape)``.
+        theta: torch.Tensor
+            Parameters, shape ``(*lead, 1)``.  Required in ``dim(theta) ==
+            1`` mode; ignored (and may be ``None``) in pinned mode, where
+            ``s`` supplies :math:`\theta(s)` instead.
+        s: torch.Tensor
+            Path parameters, shape ``(*lead,)``.  Required in pinned mode;
+            ignored in ``dim(theta) == 1`` mode.
+        spatial_score: ScoreEstimator
+            :class:`~nami.scores.base.ScoreEstimator` for
+            :math:`\nabla_x \log p_\theta(x)`.
+        divergence_estimator: DivergenceEstimator
+            Estimator for :math:`\Delta_x\phi`; defaults to
+            :class:`~nami.divergence.ExactDivergence`.
+
+        Returns
+        -------
+        torch.Tensor, shape ``(*lead, 1)``
+            In ``dim(theta) == 1`` mode the estimated joint score; in
+            pinned mode the estimated **directional** (along-path) score
+            :math:`\tfrac{d}{ds}\log\hat p_{\theta(s)}(x)`.
+        """
+        if divergence_estimator is None:
+            divergence_estimator = ExactDivergence()
+
+        if self.pinned:
+            if s is None:
+                msg = "pinned-mode score_supply requires the path parameter s"
+                raise ValueError(msg)
+            theta_eval, _ = self._path_at(s, x)
+        else:
+            if theta is None:
+                msg = "score_supply requires theta in dim(theta) == 1 mode"
+                raise ValueError(msg)
+            theta_eval = theta
+
+        grad_phi = self._field.velocity(x, theta_eval, create_graph=False)
+        t_dummy = torch.zeros((), device=x.device, dtype=x.dtype)
+        lap = divergence_estimator(self._field.velocity_field(), x, t_dummy, theta_eval)
+        with torch.no_grad():
+            grad_logp = spatial_score(x, theta_eval)
+
+        return (-lap).unsqueeze(-1) - (grad_phi * grad_logp).sum(dim=-1, keepdim=True)
+
+
+# Pyright needs the forward reference; the docstring already names it.
+ParameterFlow.__annotations__["forward"] = "ParameterFlowProcess"

--- a/src/nami/processes/parameter_flow.py
+++ b/src/nami/processes/parameter_flow.py
@@ -146,6 +146,19 @@ class ParameterFlowProcess(ProcessRuntimeMixin):
         dtheta = self._path.dtheta_ds(s_)
         return theta, dtheta
 
+    def _dtheta_for_event(self, dtheta: torch.Tensor, like: torch.Tensor) -> torch.Tensor:
+        r"""Reshape ``(*lead, 1)`` :math:`\dot\theta` to broadcast over the event.
+
+        In ``dim(theta) == 1`` mode :math:`\dot\theta` has shape ``(*lead,
+        1)``, which broadcasts against a flat event ``(*lead, d_x)`` but
+        not a multi-axis one like ``(*lead, C, H, W)``.  Reshape to ``(*lead,)
+        + (1,) * event_ndim`` so the scalar scales the velocity over any
+        event shape.  Identity for ``event_ndim == 1``.
+        """
+        event_ndim = len(self.event_shape)
+        lead = like.shape[: like.ndim - event_ndim]
+        return dtheta.reshape(*lead, *([1] * event_ndim))
+
     def transport(self, x_at_theta0: torch.Tensor) -> torch.Tensor:
         r"""Transport samples from :math:`p_{\theta_0}` to :math:`p_{\theta_1}`.
 
@@ -164,7 +177,7 @@ class ParameterFlowProcess(ProcessRuntimeMixin):
         def f(xi, s):
             theta, dtheta = self._path_at(s, xi)
             v = self._field.velocity(xi, theta, create_graph=False)
-            return v if pinned else v * dtheta
+            return v if pinned else v * self._dtheta_for_event(dtheta, xi)
 
         return self._integrate(f, x_at_theta0, t0=self._s0, t1=self._s1)
 
@@ -211,7 +224,7 @@ class ParameterFlowProcess(ProcessRuntimeMixin):
             if pinned:
                 return v, -lap
             div = lap * dtheta.squeeze(-1)
-            return v * dtheta, -div
+            return v * self._dtheta_for_event(dtheta, xi), -div
 
         kwargs = {}
         if getattr(self._solver, "requires_steps", False):

--- a/src/nami/scores/__init__.py
+++ b/src/nami/scores/__init__.py
@@ -1,0 +1,17 @@
+"""Score-estimator protocol and suppliers."""
+
+from __future__ import annotations
+
+from nami.scores.base import ScoreEstimator
+from nami.scores.ctsm import CTSMJointScore
+from nami.scores.dsm import DSMSpatialScore
+from nami.scores.mined import MinedJointScore
+from nami.scores.oracle import OracleScore
+
+__all__ = [
+    "CTSMJointScore",
+    "DSMSpatialScore",
+    "MinedJointScore",
+    "OracleScore",
+    "ScoreEstimator",
+]

--- a/src/nami/scores/base.py
+++ b/src/nami/scores/base.py
@@ -1,0 +1,25 @@
+r"""Score-estimator protocol for parameter-flow training and recovery.
+
+A score estimator supplies one of the two frozen regression targets consumed
+by :func:`~nami.losses.parameter_flow.parameter_flow_loss`
+(and, at evaluation time, by :meth:`~nami.processes.parameter_flow.ParameterFlowProcess.score_supply`):
+
+- joint score :math:`\partial_\theta \log p_\theta(x)`, returned with shape ``(lead, d_theta)``;
+- spatial score :math:`\nabla_x \log p_\theta(x)`, returned with shape ``(lead, d_x)``.
+
+Both roles share one calling convention, ``(x, theta) -> Tensor``; the trailing dimension distinguishes them.
+Estimators are upstream objects; the parameter-flow loss never trains them.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+import torch
+
+
+@runtime_checkable
+class ScoreEstimator(Protocol):
+    """Generic score interface for both joint (theta) and spatial (x)."""
+
+    def __call__(self, x: torch.Tensor, theta: torch.Tensor) -> torch.Tensor: ...

--- a/src/nami/scores/ctsm.py
+++ b/src/nami/scores/ctsm.py
@@ -1,0 +1,134 @@
+r"""Joint score via Conditional Time Score Matching (CTSM)."""
+
+from __future__ import annotations
+
+import torch
+
+from nami.paths.parameter import LinearParameterPath
+
+
+class CTSMJointScore:
+    r"""Joint score :math:`\partial_\theta\log p_\theta(x)` from a trained time-score net.
+
+    Wraps a **trained** time-score network
+    ``net(x, s) -> d/ds log p_{theta(s)}(x)`` (the scalar along-path
+    log-density derivative; train it with
+    :func:`~nami.losses.score_matching.time_score_matching_loss`) together
+    with the :class:`~nami.paths.parameter.ParameterPath` it was trained
+    on.  ``__call__(x, theta)`` inverts the path to recover ``s`` and then
+    converts the time score to the joint score.
+
+    The net learns the **scalar** derivative along the path,
+    :math:`\tfrac{d}{ds}\log p = \dot\theta(s)\cdot\partial_\theta\log p`.
+    Converting it to the joint score :math:`\partial_\theta\log p`
+    (shape ``(*lead, d_theta)``) requires undoing the chain rule against
+    the path tangent :math:`\dot\theta(s)`:
+
+    - ``d_theta == 1``: :math:`\dot\theta` is a non-zero scalar, so
+      :math:`\partial_\theta\log p = (\tfrac{d}{ds}\log p)/\dot\theta`,
+      returned with shape ``(*lead, 1)``.  Exact.
+    - ``d_theta > 1``: the **full** joint score is **not** recoverable
+      from a single directional derivative — dividing by a vector is
+      ill-posed; the time score constrains only the component of
+      :math:`\partial_\theta\log p` along :math:`\dot\theta`.  By default
+      this raises.  Pass ``directional=True`` to instead return the
+      honest **directional** score
+      :math:`\tfrac{d}{ds}\log p = \dot\theta\cdot\partial_\theta\log p`
+      as a scalar, shape ``(*lead, 1)``. Feed it to
+      :func:`~nami.losses.parameter_flow.path_pinned_parameter_flow_loss`
+      with ``directional_score=True``, which consumes the already-contracted
+      derivative directly.
+
+    This mirrors the path-locked caveat of path-pinned parameter flow: a
+    single along-path object cannot reconstruct the full multi-theta
+    geometry.
+
+    Parameters
+    ----------
+    trained_time_score_net: nn.Module
+        Callable ``(x, s) -> Tensor`` of shape ``(*lead, 1)`` or
+        ``(*lead,)``, estimating :math:`\tfrac{d}{ds}\log p_{\theta(s)}(x)`.
+    path: ParameterPath
+        The :class:`~nami.paths.parameter.ParameterPath` used in training.
+        Path inversion is implemented for
+        :class:`~nami.paths.parameter.LinearParameterPath`.
+    directional: bool
+        For ``d_theta > 1``, return the scalar directional score instead
+        of raising.  Ignored for ``d_theta == 1``.
+    on_segment_atol: float
+        Absolute tolerance for the on-segment validation of ``theta``.
+    """
+
+    def __init__(
+        self,
+        trained_time_score_net,
+        path,
+        *,
+        directional: bool = False,
+        on_segment_atol: float = 1e-4,
+    ):
+        self.net = trained_time_score_net
+        self.path = path
+        self.directional = bool(directional)
+        self.on_segment_atol = float(on_segment_atol)
+
+    def _invert_path(self, theta: torch.Tensor) -> torch.Tensor:
+        r"""Recover ``s`` from ``theta`` on a linear path; validate on-segment.
+
+        For :math:`\theta(s) = (1-s)\theta_0 + s\theta_1`,
+        :math:`s = \tfrac{(\theta - \theta_0)\cdot\Delta\theta}{|\Delta\theta|^2}`
+        with :math:`\Delta\theta = \theta_1 - \theta_0`.  Rejects ``theta``
+        that does not lie on the segment within tolerance.
+        """
+        if not isinstance(self.path, LinearParameterPath):
+            msg = (
+                "CTSMJointScore path inversion is implemented for "
+                "LinearParameterPath only; got "
+                f"{type(self.path).__name__}"
+            )
+            raise NotImplementedError(msg)
+
+        theta_0 = self.path.theta_0.to(theta)
+        delta = (self.path.theta_1 - self.path.theta_0).to(theta)
+        denom = (delta * delta).sum()
+        if denom <= 0:
+            msg = "degenerate path: theta_0 == theta_1, cannot invert"
+            raise ValueError(msg)
+
+        s = ((theta - theta_0) * delta).sum(dim=-1) / denom
+        # Validate theta lies on the segment: theta_0 + s * delta == theta.
+        recon = theta_0 + s.unsqueeze(-1) * delta
+        if not torch.allclose(recon, theta, atol=self.on_segment_atol):
+            max_dev = (recon - theta).abs().max().item()
+            msg = (
+                "theta is not on the training path's segment within "
+                f"on_segment_atol={self.on_segment_atol} (max deviation "
+                f"{max_dev:.3e}); a path-locked CTSM score is only valid on "
+                "its own path"
+            )
+            raise ValueError(msg)
+        return s
+
+    def __call__(self, x: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+        s = self._invert_path(theta)
+        time_score = self.net(x, s)
+        if time_score.shape[-1:] != (1,):
+            time_score = time_score.unsqueeze(-1)  # (*lead, 1)
+
+        delta = (self.path.theta_1 - self.path.theta_0).to(theta)
+        d_theta = delta.shape[-1]
+
+        if d_theta == 1:
+            dtheta = delta.reshape(*([1] * (theta.ndim - 1)), 1)
+            return time_score / dtheta
+
+        if self.directional:
+            return time_score  # scalar directional score, shape (*lead, 1)
+
+        msg = (
+            "CTSMJointScore cannot recover the full joint score for "
+            f"d_theta={d_theta} > 1: a single along-path time derivative "
+            "constrains only the directional score.  Pass directional=True "
+            "to return the scalar directional score d/ds log p instead."
+        )
+        raise ValueError(msg)

--- a/src/nami/scores/ctsm.py
+++ b/src/nami/scores/ctsm.py
@@ -10,15 +10,15 @@ from nami.paths.parameter import LinearParameterPath
 class CTSMJointScore:
     r"""Joint score :math:`\partial_\theta\log p_\theta(x)` from a trained time-score net.
 
-    Wraps a **trained** time-score network
+    Wraps a trained time-score network
     ``net(x, s) -> d/ds log p_{theta(s)}(x)`` (the scalar along-path
-    log-density derivative; train it with
+    log-density derivative. Train it with
     :func:`~nami.losses.score_matching.time_score_matching_loss`) together
     with the :class:`~nami.paths.parameter.ParameterPath` it was trained
     on.  ``__call__(x, theta)`` inverts the path to recover ``s`` and then
     converts the time score to the joint score.
 
-    The net learns the **scalar** derivative along the path,
+    The net learns the scalar derivative along the path,
     :math:`\tfrac{d}{ds}\log p = \dot\theta(s)\cdot\partial_\theta\log p`.
     Converting it to the joint score :math:`\partial_\theta\log p`
     (shape ``(*lead, d_theta)``) requires undoing the chain rule against
@@ -74,11 +74,6 @@ class CTSMJointScore:
 
     def _invert_path(self, theta: torch.Tensor) -> torch.Tensor:
         r"""Recover ``s`` from ``theta`` on a linear path; validate on-segment.
-
-        For :math:`\theta(s) = (1-s)\theta_0 + s\theta_1`,
-        :math:`s = \tfrac{(\theta - \theta_0)\cdot\Delta\theta}{|\Delta\theta|^2}`
-        with :math:`\Delta\theta = \theta_1 - \theta_0`.  Rejects ``theta``
-        that does not lie on the segment within tolerance.
         """
         if not isinstance(self.path, LinearParameterPath):
             msg = (
@@ -107,13 +102,34 @@ class CTSMJointScore:
                 "its own path"
             )
             raise ValueError(msg)
+        
+        # reject theta that is collinear but falls outside [0, 1] (the trained
+        atol = self.on_segment_atol
+        if (s < -atol).any() or (s > 1.0 + atol).any():
+            s_min, s_max = s.min().item(), s.max().item()
+            msg = (
+                "theta is collinear with the path but maps to a path "
+                f"coordinate s in [{s_min:.3e}, {s_max:.3e}] outside the "
+                f"trained segment [0, 1] (atol={atol}); the time-score net "
+                "was trained only on s in [0, 1] and extrapolating it is "
+                "unsupported. Pass on_segment_atol=0 to reject any theta "
+            )
+            raise ValueError(msg)
         return s
 
     def __call__(self, x: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
         s = self._invert_path(theta)
         time_score = self.net(x, s)
-        if time_score.shape[-1:] != (1,):
+        # reject net output that is not a scalar along-path derivative
+        if time_score.shape == s.shape:
             time_score = time_score.unsqueeze(-1)  # (*lead, 1)
+        elif time_score.shape != s.shape + (1,):
+            msg = (
+                f"time-score net returned shape {tuple(time_score.shape)}; "
+                f"expected {tuple(s.shape)} or {tuple(s.shape + (1,))} (a "
+                "scalar along-path derivative per sample)"
+            )
+            raise ValueError(msg)
 
         delta = (self.path.theta_1 - self.path.theta_0).to(theta)
         d_theta = delta.shape[-1]

--- a/src/nami/scores/dsm.py
+++ b/src/nami/scores/dsm.py
@@ -1,0 +1,40 @@
+r"""Spatial score via denoising score matching, amortised in theta."""
+
+from __future__ import annotations
+
+import torch
+
+
+class DSMSpatialScore:
+    r"""Spatial score :math:`\nabla_x\log p_\theta(x)` from a trained DSM net.
+
+    Thin adapter: wraps a network ``net(x, theta) -> grad_x log p_theta``
+    trained by :func:`~nami.losses.score_matching.denoising_score_matching_loss`
+    (denoising score matching, Vincent 2011, amortised over
+    :math:`\theta`).  Carries the
+    :class:`~nami.scores.base.ScoreEstimator` shape contract so the
+    trained net can be a frozen target for the parameter-flow loss.
+
+    This is the **default** route for spatial-score input.
+
+    Alternative ``CTSMSpatialScore`` (not implemented yet)
+    ----------------------------------------------------
+    The spatial score can instead be obtained by autodiff through a
+    trained CTSM time-score network (Eq. 32 of Yu 2025), avoiding a second
+    trained network.  That route carries the Liu et al. 2024
+    reliability caveat: the autodiff-through-time-score spatial estimate
+    can be inaccurate where the time-score net is itself poorly fit, so it
+    is not the default and is flagged here rather than shipped. Only DSM
+    is implemented.
+
+    Parameters
+    ----------
+    trained_dsm_net: nn.Module
+        Callable ``(x, theta) -> Tensor`` of shape ``(*lead, d_x)``.
+    """
+
+    def __init__(self, trained_dsm_net):
+        self.net = trained_dsm_net
+
+    def __call__(self, x: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+        return self.net(x, theta)

--- a/src/nami/scores/mined.py
+++ b/src/nami/scores/mined.py
@@ -1,0 +1,32 @@
+r"""Joint score via the mining-gold identity."""
+
+from __future__ import annotations
+
+import torch
+
+
+class MinedJointScore:
+    r"""Joint score :math:`\partial_\theta \log p_\theta(x)` via mining-gold.
+
+    Wraps a simulator's per-event score interface (closed-form latent
+    likelihoods, or autodiff through a matrix element).  Not a trained
+    network — delegates entirely to simulator instrumentation; the
+    class exists so simulator-supplied scores carry the
+    :class:`~nami.scores.base.ScoreEstimator` shape contract explicitly.
+
+    References
+    ----------
+    - Brehmer, Louppe, Pavez, Cranmer, *Mining gold from implicit
+      models to improve likelihood-free inference*, PNAS 2020.
+
+    Parameters
+    ----------
+    simulator_score_fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+        Callable ``(x, theta) -> Tensor`` of shape ``(*lead, d_theta)``.
+    """
+
+    def __init__(self, simulator_score_fn):
+        self.simulator_score_fn = simulator_score_fn
+
+    def __call__(self, x: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+        return self.simulator_score_fn(x, theta)

--- a/src/nami/scores/oracle.py
+++ b/src/nami/scores/oracle.py
@@ -1,0 +1,29 @@
+r"""Closed-form score supplier."""
+
+from __future__ import annotations
+
+import torch
+
+
+class OracleScore:
+    r"""Closed-form :math:`\nabla \log p_\theta` — wraps a user callable.
+
+    For analytic toy families (e.g. the 1-d linear-tilt and 2-d
+    Gaussian-mean) both joint and spatial scores are
+    closed-form. Also the natural adapter around a differentiable simulator's
+    analytic per-event likelihood (e.g. a ``LatentLikelihood.score_latent``)
+    which returns the score in the same shape convention (e.g. umi).
+
+    Parameters
+    ----------
+    fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+        Callable ``(x, theta) -> Tensor`` returning the score with the
+        protocol's shape convention: ``(*lead, d_theta)`` for joint
+        scores, ``(*lead, d_x)`` for spatial scores.
+    """
+
+    def __init__(self, fn):
+        self.fn = fn
+
+    def __call__(self, x: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+        return self.fn(x, theta)

--- a/tests/fields/test_scalar_potential.py
+++ b/tests/fields/test_scalar_potential.py
@@ -92,3 +92,9 @@ def test_velocity_field_adapter_exposes_protocol(field):
     assert adapter.event_ndim == 1
     assert adapter.event_shape == (2,)
     assert adapter.spec is field.spec
+
+
+def test_velocity_field_requires_context(field):
+    adapter = field.velocity_field()
+    with pytest.raises(ValueError, match="requires theta as the context"):
+        adapter(torch.randn(4, 2), None, None)

--- a/tests/fields/test_scalar_potential.py
+++ b/tests/fields/test_scalar_potential.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from nami.divergence import ExactDivergence
+from nami.fields.scalar_potential import ScalarPotentialField
+
+
+@pytest.fixture
+def field() -> ScalarPotentialField:
+    torch.manual_seed(0)
+    return ScalarPotentialField(2, theta_dim=1, hidden=16, layers=2)
+
+
+def test_forward_scalar_shape(field):
+    x = torch.randn(5, 2)
+    theta = torch.randn(5, 1)
+    phi = field(x, None, theta)
+    assert phi.shape == (5,)
+
+
+def test_forward_requires_theta(field):
+    with pytest.raises(ValueError, match="conditioning input"):
+        field(torch.randn(5, 2), None, None)
+
+
+def test_constructor_rejects_nonpositive_theta_dim():
+    with pytest.raises(ValueError, match="theta_dim must be positive"):
+        ScalarPotentialField(2, theta_dim=0)
+
+
+def test_velocity_matches_finite_difference(field):
+    x = torch.randn(4, 2, dtype=torch.float64)
+    theta = torch.randn(4, 1, dtype=torch.float64)
+    field = field.double()
+
+    v = field.velocity(x, theta)
+
+    eps = 1e-6
+    for i in range(2):
+        dx = torch.zeros_like(x)
+        dx[:, i] = eps
+        fd = (field(x + dx, None, theta) - field(x - dx, None, theta)) / (2 * eps)
+        torch.testing.assert_close(v[:, i], fd, atol=1e-5, rtol=1e-5)
+
+
+def test_velocity_is_curl_free(field):
+    # v = grad(phi) has a symmetric Jacobian: d v_i / d x_j == d v_j / d x_i.
+    field = field.double()
+    x = torch.randn(3, 2, dtype=torch.float64, requires_grad=True)
+    theta = torch.randn(3, 1, dtype=torch.float64)
+
+    v = field.velocity(x, theta)
+    jac_rows = [
+        torch.autograd.grad(v[:, i].sum(), x, create_graph=True)[0] for i in range(2)
+    ]
+    torch.testing.assert_close(jac_rows[0][:, 1], jac_rows[1][:, 0])
+
+
+def test_velocity_works_inside_no_grad(field):
+    x = torch.randn(4, 2)
+    theta = torch.randn(4, 1)
+    with torch.no_grad():
+        v = field.velocity(x, theta, create_graph=False)
+    assert v.shape == (4, 2)
+
+
+def test_divergence_of_velocity_field_is_laplacian(field):
+    # ExactDivergence applied to the gradient-field adapter computes
+    # div(grad(phi)) = Laplacian(phi); cross-check against a manual
+    # double-autograd trace.
+    field = field.double()
+    x = torch.randn(4, 2, dtype=torch.float64)
+    theta = torch.randn(4, 1, dtype=torch.float64)
+
+    lap = ExactDivergence(max_dim=8)(field.velocity_field(), x, None, theta)
+
+    xx = x.clone().requires_grad_(True)
+    phi = field(xx, None, theta)
+    (grad_phi,) = torch.autograd.grad(phi.sum(), xx, create_graph=True)
+    manual = sum(
+        torch.autograd.grad(grad_phi[:, i].sum(), xx, create_graph=True)[0][:, i]
+        for i in range(2)
+    )
+
+    torch.testing.assert_close(lap, manual.detach())
+
+
+def test_velocity_field_adapter_exposes_protocol(field):
+    adapter = field.velocity_field()
+    assert adapter.event_ndim == 1
+    assert adapter.event_shape == (2,)
+    assert adapter.spec is field.spec

--- a/tests/losses/test_parameter_flow_loss.py
+++ b/tests/losses/test_parameter_flow_loss.py
@@ -132,6 +132,49 @@ def test_loss_explicit_estimator_matches_default():
     torch.testing.assert_close(default, explicit)
 
 
+def test_loss_rejects_non_flat_event():
+    class _Event2:
+        event_ndim = 2
+
+    joint, spatial = _gaussian_mean_scores()
+    with pytest.raises(ValueError, match="event_ndim == 1"):
+        parameter_flow_loss(
+            _Event2(),
+            x=torch.randn(4, 1),
+            theta=torch.randn(4, 1),
+            joint_score=joint,
+            spatial_score=spatial,
+        )
+
+
+def test_loss_rejects_joint_score_shape_mismatch():
+    _, spatial = _gaussian_mean_scores()
+    bad_joint = OracleScore(lambda _x, theta: theta.expand(*theta.shape[:-1], 2))
+    with pytest.raises(ValueError, match="joint_score returned shape"):
+        parameter_flow_loss(
+            _AnalyticPotential(),
+            x=torch.randn(4, 1),
+            theta=torch.randn(4, 1),
+            joint_score=bad_joint,
+            spatial_score=spatial,
+            create_graph=False,
+        )
+
+
+def test_loss_rejects_spatial_score_shape_mismatch():
+    joint, _ = _gaussian_mean_scores()
+    bad_spatial = OracleScore(lambda x, _theta: x.expand(*x.shape[:-1], 2))
+    with pytest.raises(ValueError, match="spatial_score returned shape"):
+        parameter_flow_loss(
+            _AnalyticPotential(),
+            x=torch.randn(4, 1),
+            theta=torch.randn(4, 1),
+            joint_score=joint,
+            spatial_score=bad_spatial,
+            create_graph=False,
+        )
+
+
 def test_loss_rejects_multi_theta():
     field = ScalarPotentialField(1, theta_dim=2, hidden=8, layers=2)
     joint, spatial = _gaussian_mean_scores()

--- a/tests/losses/test_parameter_flow_loss.py
+++ b/tests/losses/test_parameter_flow_loss.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from nami.core.specs import TensorSpec
+from nami.divergence import ExactDivergence
+from nami.fields.scalar_potential import ScalarPotentialField
+from nami.losses.parameter_flow import parameter_flow_loss
+from nami.scores import OracleScore
+
+
+class _AnalyticPotential:
+    """phi(x, theta) = sum(x): velocity 1, Laplacian 0.
+
+    Exact solution of the parameter-flow PDE for the Gaussian-mean
+    family p_theta = N(theta, 1): the mean shifts at unit rate, so
+    d/dtheta log p = (x - theta) = -(d/dx log p) and the residual
+    (x - theta) + 0 + 1 * (theta - x) vanishes identically.
+    """
+
+    spec = TensorSpec((1,))
+    event_ndim = 1
+    event_shape = (1,)
+
+    def __call__(self, x, t=None, c=None):
+        del t, c
+        return x.sum(dim=-1)
+
+    def velocity(self, x, theta, *, create_graph=True):
+        del theta, create_graph
+        return torch.ones_like(x)
+
+    def velocity_field(self, *, create_graph=True):
+        del create_graph
+        return _AnalyticGradient()
+
+
+class _AnalyticGradient:
+    spec = TensorSpec((1,))
+    event_ndim = 1
+    event_shape = (1,)
+
+    def __call__(self, x, t=None, c=None):
+        del t, c
+        # x * 0 keeps the output attached to x's graph so divergence
+        # estimators can differentiate the (zero) Jacobian.
+        return x * 0 + 1.0
+
+
+def _gaussian_mean_scores():
+    joint = OracleScore(lambda x, theta: x - theta)
+    spatial = OracleScore(lambda x, theta: theta - x)
+    return joint, spatial
+
+
+def test_loss_zero_at_analytic_potential():
+    joint, spatial = _gaussian_mean_scores()
+    theta = torch.randn(64, 1)
+    x = theta + torch.randn(64, 1)
+
+    loss = parameter_flow_loss(
+        _AnalyticPotential(),
+        x=x,
+        theta=theta,
+        joint_score=joint,
+        spatial_score=spatial,
+        create_graph=False,
+    )
+
+    torch.testing.assert_close(loss, torch.tensor(0.0))
+
+
+def test_loss_shape_and_reduction():
+    torch.manual_seed(0)
+    field = ScalarPotentialField(1, theta_dim=1, hidden=8, layers=2)
+    joint, spatial = _gaussian_mean_scores()
+    theta = torch.randn(16, 1)
+    x = theta + torch.randn(16, 1)
+    kwargs = {"x": x, "theta": theta, "joint_score": joint, "spatial_score": spatial}
+
+    per_sample = parameter_flow_loss(field, reduction="none", **kwargs)
+    summed = parameter_flow_loss(field, reduction="sum", **kwargs)
+    mean = parameter_flow_loss(field, reduction="mean", **kwargs)
+
+    assert per_sample.shape == (16,)
+    torch.testing.assert_close(summed, per_sample.sum())
+    torch.testing.assert_close(mean, per_sample.mean())
+
+    with pytest.raises(ValueError, match="reduction"):
+        parameter_flow_loss(field, reduction="median", **kwargs)
+
+
+def test_loss_backward_reaches_params():
+    # Guards the second-order graph: both the gradient and Laplacian
+    # terms must carry gradients back to phi's parameters.
+    torch.manual_seed(0)
+    field = ScalarPotentialField(1, theta_dim=1, hidden=8, layers=2)
+    joint, spatial = _gaussian_mean_scores()
+    theta = torch.randn(8, 1)
+    x = theta + torch.randn(8, 1)
+
+    loss = parameter_flow_loss(
+        field, x=x, theta=theta, joint_score=joint, spatial_score=spatial
+    )
+    loss.backward()
+
+    # The residual sees only derivatives of phi, so phi's output-layer
+    # bias (a constant shift) legitimately receives no gradient; the
+    # weights that shape grad(phi) and Laplacian(phi) must.
+    grads = [p.grad for p in field.parameters()]
+    nonzero = [g for g in grads if g is not None and g.abs().sum() > 0]
+    assert nonzero, "loss.backward() reached no parameters of phi"
+    assert field.backbone.net[0].weight.grad is not None
+
+
+def test_loss_explicit_estimator_matches_default():
+    torch.manual_seed(0)
+    field = ScalarPotentialField(1, theta_dim=1, hidden=8, layers=2)
+    joint, spatial = _gaussian_mean_scores()
+    theta = torch.randn(8, 1)
+    x = theta + torch.randn(8, 1)
+    kwargs = {"x": x, "theta": theta, "joint_score": joint, "spatial_score": spatial}
+
+    default = parameter_flow_loss(field, **kwargs)
+    explicit = parameter_flow_loss(
+        field,
+        divergence_estimator=ExactDivergence(create_graph=True),
+        **kwargs,
+    )
+
+    torch.testing.assert_close(default, explicit)
+
+
+def test_loss_rejects_multi_theta():
+    field = ScalarPotentialField(1, theta_dim=2, hidden=8, layers=2)
+    joint, spatial = _gaussian_mean_scores()
+    x = torch.randn(4, 1)
+    theta = torch.randn(4, 2)
+
+    with pytest.raises(ValueError, match=r"dim\(theta\) == 1"):
+        parameter_flow_loss(
+            field, x=x, theta=theta, joint_score=joint, spatial_score=spatial
+        )

--- a/tests/losses/test_score_matching.py
+++ b/tests/losses/test_score_matching.py
@@ -1,0 +1,344 @@
+r"""Tests for the upstream score-matching training losses."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+from torch import nn
+
+from nami.components import SinusoidalTimeEmbedding
+from nami.losses.score_matching import (
+    _conditional_time_score,
+    _schedule_rates,
+    ctsm_loss,
+    denoising_score_matching_loss,
+    time_score_matching_loss,
+)
+from nami.schedules.vp import VPSchedule
+from nami.scores import DSMSpatialScore
+
+
+class _ThetaConditionedNet(nn.Module):
+    """Tiny net (x, theta) -> grad_x log p, conditioned on theta."""
+
+    def __init__(self, d_x: int, d_theta: int, hidden: int = 64):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(d_x + d_theta, hidden),
+            nn.SiLU(),
+            nn.Linear(hidden, hidden),
+            nn.SiLU(),
+            nn.Linear(hidden, d_x),
+        )
+
+    def forward(self, x, theta):
+        return self.net(torch.cat([x, theta], dim=-1))
+
+def test_dsm_loss_reductions():
+    net = _ThetaConditionedNet(2, 2)
+    x = torch.randn(8, 2)
+    theta = torch.randn(8, 2)
+    noise = torch.randn(8, 2)
+    none = denoising_score_matching_loss(
+        net, x=x, theta=theta, sigma=0.5, noise=noise, reduction="none"
+    )
+    assert none.shape == (8,)
+    mean = denoising_score_matching_loss(
+        net, x=x, theta=theta, sigma=0.5, noise=noise, reduction="mean"
+    )
+    torch.testing.assert_close(mean, none.mean())
+    s = denoising_score_matching_loss(
+        net, x=x, theta=theta, sigma=0.5, noise=noise, reduction="sum"
+    )
+    torch.testing.assert_close(s, none.sum())
+
+
+def test_dsm_loss_backward():
+    net = _ThetaConditionedNet(2, 2)
+    x = torch.randn(8, 2)
+    theta = torch.randn(8, 2)
+    loss = denoising_score_matching_loss(net, x=x, theta=theta, sigma=0.3)
+    loss.backward()
+    assert any(p.grad is not None and p.grad.abs().sum() > 0 for p in net.parameters())
+
+
+def test_dsm_loss_target_matches_analytic():
+    # The DSM target is exactly (x - x_tilde)/sigma^2 = -noise/sigma; a net
+    # returning that target gives zero loss.
+    sigma = 0.4
+    noise = torch.randn(16, 2)
+
+    class _Exact:
+        def __init__(self, x):
+            self._x = x
+
+        def __call__(self, x_tilde, _theta):
+            return (self._x - x_tilde) / sigma**2
+
+    x = torch.randn(16, 2)
+    theta = torch.randn(16, 2)
+    loss = denoising_score_matching_loss(
+        _Exact(x), x=x, theta=theta, sigma=sigma, noise=noise
+    )
+    assert loss.item() < 1e-12
+
+
+def test_dsm_loss_rejects_shape_mismatch():
+    def bad(x_tilde, _theta):
+        return x_tilde[..., :1]
+
+    with pytest.raises(ValueError, match="expected x's shape"):
+        denoising_score_matching_loss(
+            bad, x=torch.randn(4, 2), theta=torch.randn(4, 2), sigma=0.5
+        )
+
+def test_time_score_loss_zero_on_exact_net():
+    target = torch.randn(10)
+
+    class _Exact:
+        def __call__(self, _x, _s):
+            return target.unsqueeze(-1)
+
+    x = torch.randn(10, 1)
+    s = torch.rand(10)
+    loss = time_score_matching_loss(_Exact(), x=x, s=s, target=target)
+    assert loss.item() < 1e-12
+
+
+def test_time_score_loss_reductions_and_backward():
+    net = nn.Sequential(nn.Linear(2, 32), nn.SiLU(), nn.Linear(32, 1))
+
+    def wrapped(x, s):
+        return net(torch.cat([x, s.unsqueeze(-1)], dim=-1))
+
+    x = torch.randn(12, 1)
+    s = torch.rand(12)
+    target = torch.randn(12)
+    none = time_score_matching_loss(wrapped, x=x, s=s, target=target, reduction="none")
+    assert none.shape == (12,)
+    mean = time_score_matching_loss(wrapped, x=x, s=s, target=target)
+    torch.testing.assert_close(mean, none.mean())
+    mean.backward()
+    assert any(p.grad is not None for p in net.parameters())
+
+
+@pytest.mark.slow
+def test_dsm_trained_recovers_gaussian_spatial_score():
+    """A DSM net trained on N(theta, I) recovers the smoothed spatial score.
+
+    The DSM minimiser is the score of the sigma-smoothed density: for
+    N(theta, I) corrupted by N(0, sigma^2 I) that is N(theta, (1+sigma^2)I),
+    whose score is (theta - x) / (1 + sigma^2).  We use a small sigma so
+    this is close to the clean score theta - x, and check both.
+    """
+    torch.manual_seed(3)
+    generator = torch.Generator().manual_seed(3)
+    sigma = 0.25
+
+    net = _ThetaConditionedNet(2, 2, hidden=128)
+    opt = torch.optim.Adam(net.parameters(), lr=1e-3)
+    for step in range(4000):
+        theta = torch.randn(1024, 2, generator=generator)
+        x = theta + torch.randn(1024, 2, generator=generator)
+        loss = denoising_score_matching_loss(net, x=x, theta=theta, sigma=sigma)
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+        if step % 1000 == 0:
+            print(f"step {step}: dsm loss {loss.item():.3e}")
+
+    dsm = DSMSpatialScore(net)
+    theta = torch.randn(4096, 2, generator=generator)
+    x = theta + torch.randn(4096, 2, generator=generator)
+    with torch.no_grad():
+        pred = dsm(x, theta)
+    smoothed = (theta - x) / (1 + sigma**2)  # DSM minimiser
+    clean = theta - x  # analytic clean score
+    rms_smoothed = (pred - smoothed).pow(2).mean().sqrt()
+    rms_clean = (pred - clean).pow(2).mean().sqrt()
+    print(
+        f"DSM RMS vs smoothed score {rms_smoothed.item():.3e}, "
+        f"vs clean score {rms_clean.item():.3e}"
+    )
+    assert rms_smoothed.item() < 0.1
+    assert rms_clean.item() < 0.15
+
+
+def _wrap_time_net(net):
+    def wrapped(x, t):
+        return net(torch.cat([x, t.unsqueeze(-1)], dim=-1))
+
+    return wrapped
+
+
+def test_ctsm_conditional_target_matches_autograd():
+    # The closed-form conditional time score must equal the autograd
+    # t-derivative of log N(x; alpha_t z, sigma_t^2 I) at fixed x.
+    torch.manual_seed(0)
+    schedule = VPSchedule(0.1, 8.0)
+    t = torch.rand(16, dtype=torch.float64) * 0.8 + 0.1
+    z = torch.randn(16, 3, dtype=torch.float64)
+    eps = torch.randn(16, 3, dtype=torch.float64)
+
+    a, s, a_dot, s_dot = _schedule_rates(schedule, t)
+    x_fixed = (a.unsqueeze(-1) * z + s.unsqueeze(-1) * eps).detach()
+    closed_form = _conditional_time_score(z, eps, a_dot, s, s_dot)
+
+    t_var = t.detach().clone().requires_grad_(True)
+    aa = schedule.alpha(t_var).unsqueeze(-1)
+    ss = schedule.sigma(t_var).unsqueeze(-1)
+    logp = (
+        -0.5 * 3 * math.log(2 * math.pi)
+        - 3 * torch.log(ss.squeeze(-1))
+        - (x_fixed - aa * z).pow(2).sum(-1) / (2 * ss.squeeze(-1) ** 2)
+    )
+    (autograd_score,) = torch.autograd.grad(logp.sum(), t_var)
+
+    torch.testing.assert_close(closed_form, autograd_score, atol=1e-9, rtol=1e-9)
+
+
+def test_ctsm_loss_shapes_reductions_backward():
+    torch.manual_seed(0)
+    net = nn.Sequential(nn.Linear(2, 32), nn.SiLU(), nn.Linear(32, 1))
+    wrapped = _wrap_time_net(net)
+    schedule = VPSchedule(0.1, 8.0)
+    x_data = torch.randn(12, 1)
+
+    none = ctsm_loss(wrapped, x_data=x_data, schedule=schedule, reduction="none")
+    assert none.shape == (12,)
+    assert torch.isfinite(none).all()
+
+    mean = ctsm_loss(
+        wrapped,
+        x_data=x_data,
+        t=torch.full((12,), 0.5),
+        noise=torch.randn(12, 1),
+        schedule=schedule,
+    )
+    mean.backward()
+    assert any(p.grad is not None and p.grad.abs().sum() > 0 for p in net.parameters())
+
+
+def test_ctsm_weighting_modes():
+    torch.manual_seed(0)
+    net = nn.Sequential(nn.Linear(2, 16), nn.SiLU(), nn.Linear(16, 1))
+    wrapped = _wrap_time_net(net)
+    schedule = VPSchedule(0.1, 8.0)
+    x_data = torch.randn(8, 1)
+    t = torch.full((8,), 0.4)
+    noise = torch.randn(8, 1)
+    kwargs = {"x_data": x_data, "t": t, "noise": noise, "schedule": schedule}
+
+    normalised = ctsm_loss(wrapped, weighting="normalised", **kwargs)
+    uniform = ctsm_loss(wrapped, weighting="uniform", **kwargs)
+    assert torch.isfinite(normalised)
+    assert torch.isfinite(uniform)
+    assert normalised.item() != uniform.item()
+
+    zero = ctsm_loss(wrapped, weighting=torch.zeros_like, **kwargs)
+    assert zero.item() == 0.0
+
+    with pytest.raises(ValueError, match="weighting"):
+        ctsm_loss(wrapped, weighting="banana", **kwargs)
+
+
+def _marginal_logp(x, t, schedule, mu1, sig1):
+    """Closed-form marginal log-density of the VP path over N(mu1, sig1^2)."""
+    a = schedule.alpha(t)
+    s = schedule.sigma(t)
+    m = a * mu1
+    v = a**2 * sig1**2 + s**2
+    return -0.5 * math.log(2 * math.pi) - 0.5 * torch.log(v) - (x - m) ** 2 / (2 * v)
+
+
+def _marginal_time_score(x, t, schedule, mu1, sig1):
+    t = t.detach().clone().requires_grad_(True)
+    logp = _marginal_logp(x, t, schedule, mu1, sig1)
+    (g,) = torch.autograd.grad(logp.sum(), t)
+    return g
+
+
+@pytest.mark.slow
+def test_ctsm_recovers_marginal_time_score_and_density_ratio():
+    """Train on conditional targets, recover the marginal time score.
+
+    The targets are high-variance per-sample noise around the marginal,
+    so matching them in expectation is the denoising trick working.  Then
+    verify the trained net satisfies the integrated density-ratio identity
+    log[p_t1/p_t0] = int net dt.
+    """
+    torch.manual_seed(11)
+    generator = torch.Generator().manual_seed(11)
+    schedule = VPSchedule(0.1, 8.0)
+    mu1, sig1 = 1.0, 0.7
+
+    t_emb = SinusoidalTimeEmbedding(16, max_period=100.0)
+    net = nn.Sequential(
+        nn.Linear(1 + 16, 128),
+        nn.SiLU(),
+        nn.Linear(128, 128),
+        nn.SiLU(),
+        nn.Linear(128, 1),
+    )
+
+    def wrapped(x, t):
+        feats = t_emb(t, leading_shape=x.shape[:-1], device=x.device, dtype=x.dtype)
+        return net(torch.cat([x, feats], dim=-1))
+
+    # The conditional targets carry several times the scale of the
+    # marginal signal (worst at small t where sigma_t -> 0), so
+    # convergence is statistics-limited: large batches + decaying lr
+    # average the noise into the conditional mean.
+    opt = torch.optim.Adam(net.parameters(), lr=1e-3)
+    sched = torch.optim.lr_scheduler.CosineAnnealingLR(opt, T_max=8000, eta_min=1e-5)
+    for step in range(8000):
+        z = mu1 + sig1 * torch.randn(4096, 1, generator=generator)
+        loss = ctsm_loss(wrapped, x_data=z, schedule=schedule, eps_t=0.05)
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+        sched.step()
+        if step % 2000 == 0:
+            print(f"step {step}: ctsm loss {loss.item():.3e}")
+
+    # (1) Marginal time score on a p_t-weighted grid at held-out times.
+    for t_eval in (0.25, 0.5, 0.75):
+        a = schedule.alpha(torch.tensor(t_eval))
+        s = schedule.sigma(torch.tensor(t_eval))
+        m = (a * mu1).item()
+        sd = float(torch.sqrt(a**2 * sig1**2 + s**2))
+        grid = torch.linspace(m - 3.5 * sd, m + 3.5 * sd, 201)
+        tt = torch.full_like(grid, t_eval)
+        with torch.no_grad():
+            pred = wrapped(grid.unsqueeze(-1), tt).squeeze(-1)
+        truth = _marginal_time_score(grid, tt, schedule, mu1, sig1)
+        w = torch.exp(_marginal_logp(grid, tt, schedule, mu1, sig1))
+        w = w / w.sum()
+        rms = ((pred - truth).pow(2) * w).sum().sqrt()
+        scale = (truth.pow(2) * w).sum().sqrt()
+        print(
+            f"t={t_eval}: weighted RMS err {rms.item():.3e} "
+            f"(truth scale {scale.item():.3e})"
+        )
+        # Within 10% of signal scale despite per-sample targets missing
+        # the marginal by ~350%.
+        assert rms.item() < 0.10 * max(scale.item(), 1.0)
+
+    # (2) Integrated identity: int_{t0}^{t1} net(x, t) dt = log p_t1 - log p_t0.
+    t0, t1 = 0.15, 0.9
+    taus = torch.linspace(t0, t1, 201)
+    for x_val in (0.0, 0.5, 1.0, 1.5):
+        x_rep = torch.full_like(taus, x_val)
+        with torch.no_grad():
+            integrand = wrapped(x_rep.unsqueeze(-1), taus).squeeze(-1)
+        integral = torch.trapezoid(integrand, taus)
+        truth = _marginal_logp(
+            torch.tensor(x_val), torch.tensor(t1), schedule, mu1, sig1
+        ) - _marginal_logp(torch.tensor(x_val), torch.tensor(t0), schedule, mu1, sig1)
+        err = (integral - truth).abs().item()
+        print(
+            f"x={x_val}: int net dt = {integral:.4f}, truth {truth:.4f}, err {err:.3e}"
+        )
+        assert err < 0.1

--- a/tests/losses/test_score_matching.py
+++ b/tests/losses/test_score_matching.py
@@ -85,6 +85,28 @@ def test_dsm_loss_target_matches_analytic():
     assert loss.item() < 1e-12
 
 
+def test_dsm_loss_per_sample_sigma_vector_event():
+    # A natural per-sample sigma of shape (batch,) must broadcast against a
+    # vector event (batch, d_x): the loss promotes it to (batch, 1) so
+    # sigma * noise broadcasts over the event dim instead of misaligning.
+    noise = torch.randn(8, 2)
+    sigma = torch.rand(8) + 0.1  # per-sample, shape (batch,)
+
+    class _Exact:
+        def __init__(self, x):
+            self._x = x
+
+        def __call__(self, x_tilde, _theta):
+            return (self._x - x_tilde) / sigma.unsqueeze(-1) ** 2
+
+    x = torch.randn(8, 2)
+    theta = torch.randn(8, 2)
+    loss = denoising_score_matching_loss(
+        _Exact(x), x=x, theta=theta, sigma=sigma, noise=noise
+    )
+    assert loss.item() < 1e-12
+
+
 def test_dsm_loss_rejects_shape_mismatch():
     def bad(x_tilde, _theta):
         return x_tilde[..., :1]

--- a/tests/losses/test_score_matching.py
+++ b/tests/losses/test_score_matching.py
@@ -107,6 +107,29 @@ def test_time_score_loss_zero_on_exact_net():
     assert loss.item() < 1e-12
 
 
+def test_time_score_loss_squeezes_trailing_one_target():
+    target = torch.randn(10, 1)
+
+    class _Exact:
+        def __call__(self, _x, _s):
+            return target
+
+    loss = time_score_matching_loss(
+        _Exact(), x=torch.randn(10, 1), s=torch.rand(10), target=target
+    )
+    assert loss.item() < 1e-12
+
+
+def test_time_score_loss_rejects_shape_mismatch():
+    def net(x, _s):
+        return x.expand(*x.shape[:-1], 2)
+
+    with pytest.raises(ValueError, match="does not match"):
+        time_score_matching_loss(
+            net, x=torch.randn(6, 1), s=torch.rand(6), target=torch.randn(6)
+        )
+
+
 def test_time_score_loss_reductions_and_backward():
     net = nn.Sequential(nn.Linear(2, 32), nn.SiLU(), nn.Linear(32, 1))
 
@@ -219,6 +242,34 @@ def test_ctsm_loss_shapes_reductions_backward():
     )
     mean.backward()
     assert any(p.grad is not None and p.grad.abs().sum() > 0 for p in net.parameters())
+
+
+def test_ctsm_rejects_net_shape_mismatch():
+    schedule = VPSchedule(0.1, 8.0)
+    x_data = torch.randn(6, 1)
+
+    def bad(x, _t):
+        return x.expand(*x.shape[:-1], 2)
+
+    with pytest.raises(ValueError, match="does not match"):
+        ctsm_loss(bad, x_data=x_data, t=torch.full((6,), 0.4), schedule=schedule)
+
+
+def test_ctsm_callable_weighting_broadcasts_scalar():
+    net = nn.Sequential(nn.Linear(2, 16), nn.SiLU(), nn.Linear(16, 1))
+    wrapped = _wrap_time_net(net)
+    schedule = VPSchedule(0.1, 8.0)
+    kwargs = {
+        "x_data": torch.randn(8, 1),
+        "t": torch.full((8,), 0.4),
+        "noise": torch.randn(8, 1),
+        "schedule": schedule,
+    }
+
+    scalar_w = ctsm_loss(wrapped, weighting=lambda _t: torch.tensor(0.5), **kwargs)
+    uniform = ctsm_loss(wrapped, weighting="uniform", **kwargs)
+    assert torch.isfinite(scalar_w)
+    torch.testing.assert_close(scalar_w, 0.5 * uniform)
 
 
 def test_ctsm_weighting_modes():

--- a/tests/paths/test_parameter.py
+++ b/tests/paths/test_parameter.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from nami.paths import FisherRaoGeodesicPath, LinearParameterPath, ParameterPath
+
+
+def test_linear_path_endpoints():
+    theta_0 = torch.tensor([-0.5])
+    theta_1 = torch.tensor([0.5])
+    path = LinearParameterPath(theta_0, theta_1)
+
+    torch.testing.assert_close(path.theta(torch.zeros(3)), theta_0.expand(3, 1))
+    torch.testing.assert_close(path.theta(torch.ones(3)), theta_1.expand(3, 1))
+
+
+def test_linear_path_midpoint():
+    path = LinearParameterPath(torch.tensor([0.0, 2.0]), torch.tensor([1.0, 4.0]))
+    torch.testing.assert_close(
+        path.theta(torch.tensor([0.5])), torch.tensor([[0.5, 3.0]])
+    )
+
+
+def test_linear_path_dtheta_constant():
+    theta_0 = torch.tensor([-1.0])
+    theta_1 = torch.tensor([1.0])
+    path = LinearParameterPath(theta_0, theta_1)
+
+    s = torch.linspace(0.0, 1.0, 5)
+    dtheta = path.dtheta_ds(s)
+
+    assert dtheta.shape == (5, 1)
+    torch.testing.assert_close(dtheta, (theta_1 - theta_0).expand(5, 1))
+
+
+def test_linear_path_follows_s_dtype():
+    # Endpoints are moved onto s's device/dtype, so a CPU-built path works
+    # with batches cast elsewhere (here exercised via dtype).
+    path = LinearParameterPath(torch.zeros(2), torch.ones(2))  # float32
+    s = torch.rand(4, dtype=torch.float64)
+    assert path.theta(s).dtype == torch.float64
+    assert path.dtheta_ds(s).dtype == torch.float64
+
+
+def test_linear_path_rejects_shape_mismatch():
+    with pytest.raises(ValueError, match="share a shape"):
+        LinearParameterPath(torch.zeros(1), torch.zeros(2))
+
+
+def test_linear_path_satisfies_protocol():
+    path = LinearParameterPath(torch.zeros(1), torch.ones(1))
+    assert isinstance(path, ParameterPath)
+
+
+def test_fisher_rao_is_stub():
+    # The stub deliberately lacks the protocol methods so it cannot be
+    # bound by accident.
+    assert not isinstance(FisherRaoGeodesicPath(), ParameterPath)

--- a/tests/processes/test_parameter_flow.py
+++ b/tests/processes/test_parameter_flow.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from nami import RK4
+from nami.core.specs import TensorSpec
+from nami.divergence import ExactDivergence
+from nami.fields.scalar_potential import ScalarPotentialField
+from nami.losses.parameter_flow import parameter_flow_loss
+from nami.paths import LinearParameterPath
+from nami.processes.parameter_flow import ParameterFlow, ParameterFlowProcess
+from nami.scores import OracleScore
+
+
+class _AnalyticPotential:
+    spec = TensorSpec((1,))
+    event_ndim = 1
+    event_shape = (1,)
+
+    def __call__(self, x, t=None, c=None):
+        del t, c
+        return x.sum(dim=-1)
+
+    def velocity(self, x, theta, *, create_graph=True):
+        del theta, create_graph
+        return torch.ones_like(x)
+
+    def velocity_field(self):
+        return _AnalyticGradient()
+
+
+class _AnalyticGradient:
+    spec = TensorSpec((1,))
+    event_ndim = 1
+    event_shape = (1,)
+
+    def __call__(self, x, t=None, c=None):
+        del t, c
+        # x * 0 keeps the output attached to x's graph for divergence
+        # estimators.
+        return x * 0 + 1.0
+
+
+def _unit_path() -> LinearParameterPath:
+    return LinearParameterPath(torch.tensor([0.0]), torch.tensor([1.0]))
+
+
+def test_lazy_forward_binds_path():
+    lazy = ParameterFlow(_AnalyticPotential(), RK4(steps=4))
+    process = lazy(_unit_path())
+    assert isinstance(process, ParameterFlowProcess)
+    assert process.path is not None
+
+
+def test_forward_requires_path():
+    lazy = ParameterFlow(_AnalyticPotential(), RK4(steps=4))
+    with pytest.raises(ValueError, match="requires a ParameterPath"):
+        lazy()
+
+
+def test_event_shape_property():
+    process = ParameterFlow(_AnalyticPotential(), RK4(steps=4))(_unit_path())
+    assert process.event_shape == (1,)
+
+
+def test_transport_shifts_gaussian_mean():
+    # With the analytic potential, transport along theta: 0 -> 1 is the
+    # exact shift x -> x + 1 (velocity theta-dot * grad(phi) = 1).
+    process = ParameterFlow(_AnalyticPotential(), RK4(steps=8))(_unit_path())
+    x0 = torch.randn(64, 1)
+
+    x1 = process.transport(x0)
+
+    torch.testing.assert_close(x1, x0 + 1.0)
+
+
+def test_transport_with_logp_is_exact_on_gaussian_mean():
+    # The shift map has zero divergence contribution only if Laplacian
+    # of phi is 0 — true here, so log p is carried unchanged and equals
+    # the analytic N(1, 1) log-density at the endpoint.
+    process = ParameterFlow(_AnalyticPotential(), RK4(steps=8))(_unit_path())
+    x0 = torch.randn(32, 1)
+    logp0 = -0.5 * (x0.squeeze(-1) ** 2) - 0.5 * math.log(2 * math.pi)
+
+    x1, logp1 = process.transport_with_logp(
+        x0, logp0, divergence_estimator=ExactDivergence(max_dim=4)
+    )
+
+    expected = -0.5 * ((x1.squeeze(-1) - 1.0) ** 2) - 0.5 * math.log(2 * math.pi)
+    torch.testing.assert_close(x1, x0 + 1.0)
+    torch.testing.assert_close(logp1, expected)
+
+
+def test_multi_theta_selects_pinned_mode():
+    # A path with d_theta > 1 puts the process in path-pinned mode: no
+    # theta-dot scaling, phi is the per-unit-s potential.
+    path = LinearParameterPath(torch.zeros(2), torch.ones(2))
+    process = ParameterFlow(_AnalyticPotential(), RK4(steps=2))(path)
+    assert process.pinned is True
+
+
+def test_dim1_path_is_not_pinned():
+    process = ParameterFlow(_AnalyticPotential(), RK4(steps=2))(_unit_path())
+    assert process.pinned is False
+
+
+def test_score_supply_matches_oracle_on_analytic_potential():
+    # score_supply inverts the PDE: -Lap(phi) - grad(phi) . spatial =
+    # 0 - 1 * (theta - x) = x - theta, the exact joint score of
+    # p_theta = N(theta, 1).
+    process = ParameterFlow(_AnalyticPotential(), RK4(steps=2))(_unit_path())
+    theta = torch.randn(16, 1)
+    x = theta + torch.randn(16, 1)
+    spatial = OracleScore(lambda x, theta: theta - x)
+
+    supplied = process.score_supply(x, theta, spatial_score=spatial)
+
+    torch.testing.assert_close(supplied, x - theta)
+
+
+def _p0(x: torch.Tensor) -> torch.Tensor:
+    return torch.exp(-0.5 * x**2) / math.sqrt(2 * math.pi)
+
+
+def _p_theta(x: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+    return _p0(x) * (1 + theta * torch.tanh(x))
+
+
+def _joint_score(x: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+    # Elementwise on broadcastable (x, theta); for (N, 1) inputs the
+    # output is (N, 1) = (*lead, d_theta) with d_theta = 1.
+    return torch.tanh(x) / (1 + theta * torch.tanh(x))
+
+
+def _spatial_score(x: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+    sech2 = 1.0 / torch.cosh(x) ** 2
+    return -x + theta * sech2 / (1 + theta * torch.tanh(x))
+
+
+def _grid(n: int = 4001, lo: float = -8.0, hi: float = 8.0) -> torch.Tensor:
+    return torch.linspace(lo, hi, n, dtype=torch.float64)
+
+
+def _v_analytic_on_grid(
+    grid: torch.Tensor, theta: float
+) -> tuple[torch.Tensor, torch.Tensor]:
+    integrand = _p0(grid) * torch.tanh(grid)
+    integral = torch.cat(
+        [
+            torch.zeros(1, dtype=grid.dtype),
+            torch.cumulative_trapezoid(integrand, grid),
+        ]
+    )
+    p = _p_theta(grid, torch.tensor(theta, dtype=grid.dtype))
+    return grid, -integral / p
+
+
+def _sample_p_theta(theta: torch.Tensor, generator: torch.Generator) -> torch.Tensor:
+    """Inverse-CDF sampling of p_theta on a grid, batched over theta."""
+    grid = _grid()
+    pdf = _p_theta(grid, theta.double().unsqueeze(-1))  # (n, grid)
+    cdf = torch.cat(
+        [
+            torch.zeros(pdf.shape[0], 1, dtype=pdf.dtype),
+            torch.cumulative_trapezoid(pdf, grid, dim=-1),
+        ],
+        dim=-1,
+    )
+    cdf = cdf / cdf[:, -1:]
+    u = torch.rand(theta.shape[0], 1, dtype=cdf.dtype, generator=generator)
+    idx = torch.searchsorted(cdf, u).clamp(1, grid.numel() - 1)
+    c0 = cdf.gather(-1, idx - 1)
+    c1 = cdf.gather(-1, idx)
+    frac = (u - c0) / (c1 - c0).clamp_min(1e-12)
+    x = grid[idx - 1] + frac * (grid[idx] - grid[idx - 1])
+    return x.float()
+
+
+@pytest.mark.slow
+def test_linear_tilt_recovers_analytic_velocity():
+    # Train phi on the PDE residual with oracle scores; the recovered
+    # velocity grad(phi) must match the continuity-equation solution in
+    # p_theta-weighted squared error, and score_supply must agree with
+    # the joint-score oracle on data.
+    torch.manual_seed(7)
+    generator = torch.Generator().manual_seed(7)
+
+    field = ScalarPotentialField(1, theta_dim=1, hidden=64, layers=3)
+    joint = OracleScore(_joint_score)
+    spatial = OracleScore(_spatial_score)
+
+    optimizer = torch.optim.Adam(field.parameters(), lr=1e-3)
+    for step in range(3000):
+        theta = torch.rand(512, 1, generator=generator) - 0.5  # U(-0.5, 0.5)
+        x = _sample_p_theta(theta.squeeze(-1), generator)
+        loss = parameter_flow_loss(
+            field,
+            x=x,
+            theta=theta,
+            joint_score=joint,
+            spatial_score=spatial,
+        )
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+        if step % 500 == 0:
+            print(f"step {step}: loss {loss.item():.3e}")
+
+    # Evaluate p_theta-weighted squared velocity error on a grid.
+    for theta_eval in (-0.3, 0.0, 0.4):
+        grid, v_true = _v_analytic_on_grid(_grid(801, -5.0, 5.0), theta_eval)
+        xs = grid.float().unsqueeze(-1)
+        thetas = torch.full((grid.numel(), 1), theta_eval)
+        v_model = field.velocity(xs, thetas, create_graph=False).squeeze(-1).double()
+        weights = _p_theta(grid, torch.tensor(theta_eval, dtype=grid.dtype))
+        weights = weights / torch.trapezoid(weights, grid)
+        err = torch.trapezoid((v_model - v_true) ** 2 * weights, grid)
+        print(f"theta={theta_eval}: weighted L2 err {err.item():.3e}")
+        assert err.item() < 1e-3
+
+    # The PDE inversion must agree with the joint-score oracle on data.
+    process = ParameterFlow(field, RK4(steps=32))(
+        LinearParameterPath(torch.tensor([0.0]), torch.tensor([0.4]))
+    )
+    theta = torch.zeros(2048, 1) + 0.2
+    x = _sample_p_theta(theta.squeeze(-1), generator)
+    supplied = process.score_supply(x, theta, spatial_score=spatial)
+    target = _joint_score(x, theta)
+    rms = (supplied - target).pow(2).mean().sqrt()
+    print(f"score_supply RMS error {rms.item():.3e}")
+    assert rms.item() < 0.05

--- a/tests/processes/test_parameter_flow.py
+++ b/tests/processes/test_parameter_flow.py
@@ -44,6 +44,31 @@ class _AnalyticGradient:
         return x * 0 + 1.0
 
 
+class _MultiAxisPotential:
+    """Analytic potential over a multi-axis event (constant unit velocity)."""
+
+    spec = TensorSpec((2, 2))
+    event_ndim = 2
+    event_shape = (2, 2)
+
+    def velocity(self, x, theta, *, create_graph=True):
+        del theta, create_graph
+        return torch.ones_like(x)
+
+    def velocity_field(self):
+        return _MultiAxisGradient()
+
+
+class _MultiAxisGradient:
+    spec = TensorSpec((2, 2))
+    event_ndim = 2
+    event_shape = (2, 2)
+
+    def __call__(self, x, t=None, c=None):
+        del t, c
+        return x * 0 + 1.0
+
+
 def _unit_path() -> LinearParameterPath:
     return LinearParameterPath(torch.tensor([0.0]), torch.tensor([1.0]))
 
@@ -75,6 +100,33 @@ def test_transport_shifts_gaussian_mean():
     x1 = process.transport(x0)
 
     torch.testing.assert_close(x1, x0 + 1.0)
+
+
+def test_transport_dim1_broadcasts_dtheta_over_multi_axis_event():
+    # dim(theta) == 1 scales velocity by theta-dot; for a (2, 2) event the
+    # (lead, 1) theta-dot must reshape to (lead, 1, 1) to broadcast. The
+    # unit path gives theta-dot = 1, so transport is the exact shift x+1.
+    process = ParameterFlow(_MultiAxisPotential(), RK4(steps=8))(_unit_path())
+    x0 = torch.randn(5, 2, 2)
+
+    x1 = process.transport(x0)
+
+    torch.testing.assert_close(x1, x0 + 1.0)
+
+
+def test_transport_with_logp_broadcasts_dtheta_over_multi_axis_event():
+    # The augmented transport multiplies velocity by theta-dot too; a
+    # zero-Laplacian shift carries log p unchanged over the (2, 2) event.
+    process = ParameterFlow(_MultiAxisPotential(), RK4(steps=8))(_unit_path())
+    x0 = torch.randn(4, 2, 2)
+    logp0 = torch.zeros(4)
+
+    x1, logp1 = process.transport_with_logp(
+        x0, logp0, divergence_estimator=ExactDivergence(max_dim=8)
+    )
+
+    torch.testing.assert_close(x1, x0 + 1.0)
+    torch.testing.assert_close(logp1, logp0)
 
 
 def test_transport_with_logp_is_exact_on_gaussian_mean():

--- a/tests/processes/test_parameter_flow.py
+++ b/tests/processes/test_parameter_flow.py
@@ -107,6 +107,32 @@ def test_dim1_path_is_not_pinned():
     assert process.pinned is False
 
 
+def test_field_property_returns_bound_field():
+    field = _AnalyticPotential()
+    process = ParameterFlow(field, RK4(steps=4))(_unit_path())
+    assert process.field is field
+
+
+def test_transport_raises_when_solver_requires_unset_steps():
+    class _NeedsSteps:
+        requires_steps = True
+        steps = None
+
+        def integrate(self, *_args, **_kwargs):
+            return _kwargs  # never reached: steps validation raises first
+
+    process = ParameterFlow(_AnalyticPotential(), _NeedsSteps())(_unit_path())
+    with pytest.raises(ValueError, match="solver requires steps"):
+        process.transport(torch.randn(4, 1))
+
+
+def test_score_supply_requires_theta_in_dim1_mode():
+    process = ParameterFlow(_AnalyticPotential(), RK4(steps=2))(_unit_path())
+    spatial = OracleScore(lambda x, theta: theta - x)
+    with pytest.raises(ValueError, match="requires theta in dim\\(theta\\) == 1"):
+        process.score_supply(torch.randn(4, 1), None, spatial_score=spatial)
+
+
 def test_score_supply_matches_oracle_on_analytic_potential():
     # score_supply inverts the PDE: -Lap(phi) - grad(phi) . spatial =
     # 0 - 1 * (theta - x) = x - theta, the exact joint score of

--- a/tests/processes/test_parameter_flow_mutli_path.py
+++ b/tests/processes/test_parameter_flow_mutli_path.py
@@ -1,0 +1,540 @@
+r"""path-pinned multi-theta parameter flow.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from nami import RK4
+from nami.core.specs import TensorSpec
+from nami.divergence import ExactDivergence
+from nami.fields.scalar_potential import ScalarPotentialField
+from nami.losses.parameter_flow import path_pinned_parameter_flow_loss
+from nami.paths import LinearParameterPath
+from nami.processes.parameter_flow import ParameterFlow
+from nami.scores import CTSMJointScore, OracleScore
+
+# Gaussian-mean family p_theta = N(theta, I) on R^2.
+THETA_0 = torch.tensor([0.0, 0.0])
+THETA_1 = torch.tensor([1.0, 1.0])
+
+
+def _diagonal_path() -> LinearParameterPath:
+    return LinearParameterPath(THETA_0, THETA_1)
+
+
+def _joint_score(x: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+    # d/dtheta log N(x; theta, I) = x - theta, shape (*lead, d_theta).
+    return x - theta
+
+
+def _spatial_score(x: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+    # d/dx log N(x; theta, I) = theta - x, shape (*lead, d_x).
+    return theta - x
+
+
+class _AnalyticPerUnitSPotential:
+    r"""phi(x, theta) = (theta_1 - theta_0) . x — the per-unit-s potential."""
+
+    spec = TensorSpec((2,))
+    event_ndim = 1
+    event_shape = (2,)
+
+    def __init__(self, delta: torch.Tensor):
+        self._delta = delta
+
+    def __call__(self, x, t=None, c=None):
+        del t, c
+        return (x * self._delta).sum(dim=-1)
+
+    def velocity(self, x, theta, *, create_graph=True):
+        del theta, create_graph
+        return self._delta.expand_as(x).clone()
+
+    def velocity_field(self):
+        delta = self._delta
+
+        class _Grad:
+            spec = TensorSpec((2,))
+            event_ndim = 1
+            event_shape = (2,)
+
+            def __call__(self, x, t=None, c=None):
+                del t, c
+                return x * 0 + delta
+
+        return _Grad()
+
+def test_pinned_loss_zero_on_analytic_potential():
+    path = _diagonal_path()
+    delta = THETA_1 - THETA_0
+    field = _AnalyticPerUnitSPotential(delta)
+    joint = OracleScore(_joint_score)
+    spatial = OracleScore(_spatial_score)
+
+    s = torch.rand(128)
+    theta_s = path.theta(s)
+    x = theta_s + torch.randn(128, 2)
+
+    loss = path_pinned_parameter_flow_loss(
+        field,
+        x=x,
+        s=s,
+        path=path,
+        joint_score=joint,
+        spatial_score=spatial,
+    )
+    assert loss.item() < 1e-10
+
+
+def test_pinned_loss_accepts_ctsm_directional_score():
+    # CTSMJointScore(directional=True) returns the already-contracted
+    # d/ds log p; with directional_score=True the pinned loss consumes it
+    # directly (no second tangent contraction) and the analytic potential's
+    # exact cancellation still drives the residual to zero.
+    path = _diagonal_path()
+    delta = THETA_1 - THETA_0
+    field = _AnalyticPerUnitSPotential(delta)
+    spatial = OracleScore(_spatial_score)
+
+    def time_net(x, s):
+        # d/ds log p = theta-dot . (x - theta(s)) for N(theta(s), I).
+        return (delta * (x - path.theta(s))).sum(-1, keepdim=True)
+
+    directional = CTSMJointScore(time_net, path, directional=True)
+
+    s = torch.rand(128)
+    x = path.theta(s) + torch.randn(128, 2)
+
+    loss = path_pinned_parameter_flow_loss(
+        field,
+        x=x,
+        s=s,
+        path=path,
+        joint_score=directional,
+        spatial_score=spatial,
+        directional_score=True,
+    )
+    assert loss.item() < 1e-10
+
+
+def test_pinned_transport_is_exact_shift():
+    # The analytic per-unit-s potential transports theta_0 -> theta_1 as
+    # the exact constant shift x -> x + (theta_1 - theta_0), with NO
+    # theta-dot multiplication (pinned mode).
+    path = _diagonal_path()
+    delta = THETA_1 - THETA_0
+    field = _AnalyticPerUnitSPotential(delta)
+    process = ParameterFlow(field, RK4(steps=8))(path)
+    assert process.pinned is True
+
+    x0 = torch.randn(64, 2)
+    x1 = process.transport(x0)
+
+    torch.testing.assert_close(x1, x0 + delta)
+
+
+def test_pinned_transport_with_logp_is_exact():
+    # Zero Laplacian => log-density carried unchanged; endpoint matches
+    # N(theta_1, I) evaluated at the shifted points.
+    path = _diagonal_path()
+    delta = THETA_1 - THETA_0
+    field = _AnalyticPerUnitSPotential(delta)
+    process = ParameterFlow(field, RK4(steps=8))(path)
+
+    x0 = torch.randn(32, 2)
+    logp0 = -0.5 * (x0**2).sum(-1) - math.log(2 * math.pi)
+    x1, logp1 = process.transport_with_logp(
+        x0, logp0, divergence_estimator=ExactDivergence(max_dim=4)
+    )
+
+    expected = -0.5 * ((x1 - THETA_1) ** 2).sum(-1) - math.log(2 * math.pi)
+    torch.testing.assert_close(x1, x0 + delta)
+    torch.testing.assert_close(logp1, expected)
+
+
+def test_pinned_score_supply_returns_directional_scalar():
+    # In pinned mode score_supply returns the directional (along-path)
+    # score d/ds log p, a scalar per sample, shape (*lead, 1).  For the
+    # analytic potential: -Lap - grad phi . spatial = 0 - delta.(theta-x)
+    # = delta.(x - theta) = theta-dot . joint_score.
+    path = _diagonal_path()
+    delta = THETA_1 - THETA_0
+    field = _AnalyticPerUnitSPotential(delta)
+    process = ParameterFlow(field, RK4(steps=2))(path)
+    spatial = OracleScore(_spatial_score)
+
+    s = torch.rand(16)
+    theta_s = path.theta(s)
+    x = theta_s + torch.randn(16, 2)
+
+    supplied = process.score_supply(x, s=s, spatial_score=spatial)
+    expected = (delta * _joint_score(x, theta_s)).sum(-1, keepdim=True)
+
+    assert supplied.shape == (16, 1)
+    torch.testing.assert_close(supplied, expected)
+
+
+def test_pinned_score_supply_requires_s():
+    path = _diagonal_path()
+    field = _AnalyticPerUnitSPotential(THETA_1 - THETA_0)
+    process = ParameterFlow(field, RK4(steps=2))(path)
+    spatial = OracleScore(_spatial_score)
+    with pytest.raises(ValueError, match="requires the path parameter s"):
+        process.score_supply(torch.randn(4, 2), spatial_score=spatial)
+
+
+def test_pinned_loss_rejects_bad_s_shape():
+    path = _diagonal_path()
+    field = _AnalyticPerUnitSPotential(THETA_1 - THETA_0)
+    joint = OracleScore(_joint_score)
+    spatial = OracleScore(_spatial_score)
+    x = torch.randn(8, 2)
+    with pytest.raises(ValueError, match="leading shape of x"):
+        path_pinned_parameter_flow_loss(
+            field,
+            x=x,
+            s=torch.rand(8, 1),  # wrong: should be (8,)
+            path=path,
+            joint_score=joint,
+            spatial_score=spatial,
+        )
+
+
+def test_pinned_loss_reduction_modes():
+    path = _diagonal_path()
+    field = ScalarPotentialField(2, theta_dim=2, hidden=16, layers=2)
+    joint = OracleScore(_joint_score)
+    spatial = OracleScore(_spatial_score)
+    s = torch.rand(10)
+    x = path.theta(s) + torch.randn(10, 2)
+
+    none = path_pinned_parameter_flow_loss(
+        field,
+        x=x,
+        s=s,
+        path=path,
+        joint_score=joint,
+        spatial_score=spatial,
+        reduction="none",
+    )
+    assert none.shape == (10,)
+    mean = path_pinned_parameter_flow_loss(
+        field,
+        x=x,
+        s=s,
+        path=path,
+        joint_score=joint,
+        spatial_score=spatial,
+        reduction="mean",
+    )
+    torch.testing.assert_close(mean, none.mean())
+
+
+def test_pinned_loss_backward_reaches_field():
+    path = _diagonal_path()
+    field = ScalarPotentialField(2, theta_dim=2, hidden=16, layers=2)
+    joint = OracleScore(_joint_score)
+    spatial = OracleScore(_spatial_score)
+    s = torch.rand(10)
+    x = path.theta(s) + torch.randn(10, 2)
+    loss = path_pinned_parameter_flow_loss(
+        field,
+        x=x,
+        s=s,
+        path=path,
+        joint_score=joint,
+        spatial_score=spatial,
+    )
+    loss.backward()
+    grads = [p.grad for p in field.parameters() if p.grad is not None]
+    assert grads
+    assert any(g.abs().sum() > 0 for g in grads)
+
+def _energy_distance(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    """Energy distance between two samples (pure torch).
+
+    E = 2 E||A - B|| - E||A - A'|| - E||B - B'||, all pairwise Euclidean.
+    Zero iff the distributions match; non-negative.
+    """
+
+    def _mean_pdist(u, v):
+        d = torch.cdist(u, v)
+        return d.mean()
+
+    return 2 * _mean_pdist(a, b) - _mean_pdist(a, a) - _mean_pdist(b, b)
+
+
+def _ks_statistic(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    """One-dimensional two-sample Kolmogorov-Smirnov statistic (pure torch)."""
+    a_sorted = torch.sort(a)[0]
+    b_sorted = torch.sort(b)[0]
+    grid = torch.cat([a_sorted, b_sorted])
+    cdf_a = torch.searchsorted(a_sorted, grid, right=True).float() / a.numel()
+    cdf_b = torch.searchsorted(b_sorted, grid, right=True).float() / b.numel()
+    return (cdf_a - cdf_b).abs().max()
+
+
+@pytest.mark.slow
+def test_gaussian_mean_path_pinned():
+    """Path-pinned multi-theta training on the Gaussian-mean family.
+
+    Train ScalarPotentialField(2, theta_dim=2) with the path-pinned loss
+    and oracle scores on p_theta = N(theta, I) along a fixed diagonal
+    path; the recovered grad(phi) must match the analytic per-unit-s
+    velocity (the constant theta-dot) in p-weighted L2 < 1e-3 at held-out
+    s, and transported samples from N(theta_0, I) must match N(theta_1, I)
+    by mean / variance / energy-distance / per-marginal KS checks.
+    """
+    torch.manual_seed(11)
+    generator = torch.Generator().manual_seed(11)
+
+    path = _diagonal_path()
+    delta = THETA_1 - THETA_0  # the analytic per-unit-s velocity (constant)
+    field = ScalarPotentialField(2, theta_dim=2, hidden=64, layers=3)
+    joint = OracleScore(_joint_score)
+    spatial = OracleScore(_spatial_score)
+
+    optimizer = torch.optim.Adam(field.parameters(), lr=1e-3)
+    for step in range(3000):
+        s = torch.rand(512, generator=generator)
+        theta_s = path.theta(s)
+        x = theta_s + torch.randn(512, 2, generator=generator)
+        loss = path_pinned_parameter_flow_loss(
+            field,
+            x=x,
+            s=s,
+            path=path,
+            joint_score=joint,
+            spatial_score=spatial,
+        )
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+        if step % 500 == 0:
+            print(f"step {step}: loss {loss.item():.3e}")
+
+    # Criterion (a): p-weighted L2 velocity error at held-out s.
+    for s_eval in (0.25, 0.5, 0.75):
+        s_t = torch.full((4096,), s_eval)
+        theta_s = path.theta(s_t)
+        x = theta_s + torch.randn(4096, 2, generator=generator)
+        v_model = field.velocity(x, theta_s, create_graph=False)
+        v_true = delta.expand_as(v_model)
+        err = (v_model - v_true).pow(2).sum(-1).mean()
+        print(f"s={s_eval}: p-weighted L2 velocity err {err.item():.3e}")
+        assert err.item() < 1e-3
+
+    # Criterion (b): transported samples match the truth at theta_1.
+    process = ParameterFlow(field, RK4(steps=64))(path)
+    n = 8192
+    x0 = THETA_0 + torch.randn(n, 2, generator=generator)
+    x1 = process.transport(x0)
+    truth = THETA_1 + torch.randn(n, 2, generator=generator)
+
+    mean_err = (x1.mean(0) - THETA_1).abs()
+    se = x1.std(0) / (n**0.5)
+    print(f"transported mean {x1.mean(0).tolist()}, |err| {mean_err.tolist()}")
+    assert torch.all(mean_err < 3 * se)
+
+    var_err = (x1.var(0) - 1.0).abs()
+    print(f"transported var {x1.var(0).tolist()}, |err| {var_err.tolist()}")
+    assert torch.all(var_err < 0.1)
+
+    # Energy distance against fresh truth samples (sub-sample for cdist).
+    ed = _energy_distance(x1[:2048], truth[:2048])
+    ed_ref = _energy_distance(
+        truth[:2048], (THETA_1 + torch.randn(2048, 2, generator=generator))
+    )
+    print(
+        f"energy distance transported-vs-truth {ed.item():.3e}, "
+        f"truth-vs-truth ref {ed_ref.item():.3e}"
+    )
+    assert ed.item() < 5 * ed_ref.item().__abs__() + 1e-2
+
+    # Per-marginal KS check.
+    for d in range(2):
+        ks = _ks_statistic(x1[:, d], truth[:, d])
+        print(f"dim {d}: KS statistic {ks.item():.3e}")
+        assert ks.item() < 0.05
+
+
+VAR_0 = torch.tensor([1.0, 1.0])
+VAR_1 = torch.tensor([2.25, 0.49])  # dim 0 inflates, dim 1 shrinks
+
+
+def _variance_path() -> LinearParameterPath:
+    return LinearParameterPath(VAR_0, VAR_1)
+
+
+def _var_joint_score(x: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+    return -1.0 / (2 * theta) + x.pow(2) / (2 * theta.pow(2))
+
+
+def _var_spatial_score(x: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+    return -x / theta
+
+
+def _var_velocity(x: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+    return (VAR_1 - VAR_0) * x / (2 * theta)
+
+
+def _var_laplacian(theta: torch.Tensor) -> torch.Tensor:
+    return ((VAR_1 - VAR_0) / (2 * theta)).sum(-1)
+
+
+class _AnalyticCurvedPotential:
+    r"""phi(x, theta) = sum_i Delta_i x_i^2 / (4 theta_i) — curved."""
+
+    spec = TensorSpec((2,))
+    event_ndim = 1
+    event_shape = (2,)
+
+    def __call__(self, x, t=None, c=None):
+        del t
+        return ((VAR_1 - VAR_0) * x.pow(2) / (4 * c)).sum(dim=-1)
+
+    def velocity(self, x, theta, *, create_graph=True):
+        del create_graph
+        return _var_velocity(x, theta)
+
+    def velocity_field(self):
+        class _Grad:
+            spec = TensorSpec((2,))
+            event_ndim = 1
+            event_shape = (2,)
+
+            def __call__(self, x, t=None, c=None):
+                del t
+                return _var_velocity(x, c)
+
+        return _Grad()
+
+
+def test_pinned_loss_zero_on_curved_analytic_potential():
+    # The residual must vanish through genuine cancellation of three
+    # NON-zero terms (directional joint score, Laplacian, coupling).
+    path = _variance_path()
+    field = _AnalyticCurvedPotential()
+    s = torch.rand(256)
+    theta_s = path.theta(s)
+    x = theta_s.sqrt() * torch.randn(256, 2)
+
+    loss = path_pinned_parameter_flow_loss(
+        field,
+        x=x,
+        s=s,
+        path=path,
+        joint_score=OracleScore(_var_joint_score),
+        spatial_score=OracleScore(_var_spatial_score),
+    )
+    # Sanity that the cancellation is non-trivial: the Laplacian alone is
+    # far from zero.
+    assert _var_laplacian(theta_s).abs().mean() > 0.01
+    assert loss.item() < 1e-10
+
+
+def test_analytic_transport_is_exact_anisotropic_scaling():
+    # The flow of v_i = Delta_i x_i / (2 theta_i(s)) integrates exactly to
+    # x_i -> x_i sqrt(theta_i(1)/theta_i(0)).
+    path = _variance_path()
+    field = _AnalyticCurvedPotential()
+    process = ParameterFlow(field, RK4(steps=64))(path)
+    assert process.pinned is True
+
+    x0 = torch.randn(128, 2)
+    x1 = process.transport(x0)
+
+    torch.testing.assert_close(x1, x0 * (VAR_1 / VAR_0).sqrt(), atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.slow
+def test_anisotropic_variance_path_pinned():
+    """Path-pinned training on a curved potential exercised non-trivially.
+
+    Train ScalarPotentialField on the anisotropic variance family; the
+    recovered velocity must match the x-DEPENDENT analytic velocity, the
+    recovered Laplacian must match the NON-zero analytic Laplacian, and
+    transport must reproduce the exact anisotropic scaling map both
+    sample-wise and distributionally.
+    """
+    torch.manual_seed(11)
+    generator = torch.Generator().manual_seed(11)
+
+    path = _variance_path()
+    field = ScalarPotentialField(2, theta_dim=2, hidden=64, layers=3)
+    joint = OracleScore(_var_joint_score)
+    spatial = OracleScore(_var_spatial_score)
+
+    optimizer = torch.optim.Adam(field.parameters(), lr=1e-3)
+    for step in range(4000):
+        s = torch.rand(512, generator=generator)
+        theta_s = path.theta(s)
+        x = theta_s.sqrt() * torch.randn(512, 2, generator=generator)
+        loss = path_pinned_parameter_flow_loss(
+            field,
+            x=x,
+            s=s,
+            path=path,
+            joint_score=joint,
+            spatial_score=spatial,
+        )
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+        if step % 1000 == 0:
+            print(f"step {step}: loss {loss.item():.3e}")
+
+    estimator = ExactDivergence(max_dim=4)
+    grad_field = field.velocity_field()
+    for s_eval in (0.25, 0.5, 0.75):
+        s_t = torch.full((4096,), s_eval)
+        theta_s = path.theta(s_t)
+        x = theta_s.sqrt() * torch.randn(4096, 2, generator=generator)
+
+        # (a) x-dependent velocity recovered.
+        v_model = field.velocity(x, theta_s, create_graph=False)
+        v_true = _var_velocity(x, theta_s)
+        err = (v_model - v_true).pow(2).sum(-1).mean()
+        print(f"s={s_eval}: p-weighted L2 velocity err {err.item():.3e}")
+        assert err.item() < 1e-3
+
+        # (a') the elliptic term is genuinely exercised: trained Laplacian
+        # matches the non-zero analytic one.
+        t_dummy = torch.zeros((), dtype=x.dtype)
+        lap_model = estimator(grad_field, x[:512], t_dummy, theta_s[:512])
+        lap_true = _var_laplacian(theta_s[:512])
+        lap_err = (lap_model - lap_true).abs().mean()
+        print(
+            f"s={s_eval}: Laplacian err {lap_err.item():.3e} "
+            f"(analytic terms {((VAR_1 - VAR_0) / (2 * path.theta(torch.tensor([s_eval])))).squeeze().tolist()})"
+        )
+        assert lap_err.item() < 0.05
+
+    # (b) transport: exact anisotropic scaling, sample-wise and in law.
+    process = ParameterFlow(field, RK4(steps=64))(path)
+    n = 8192
+    x0 = VAR_0.sqrt() * torch.randn(n, 2, generator=generator)
+    x1 = process.transport(x0)
+    exact = x0 * (VAR_1 / VAR_0).sqrt()
+
+    samplewise_rms = (x1 - exact).pow(2).sum(-1).mean().sqrt()
+    print(f"sample-wise RMS vs exact scaling map: {samplewise_rms.item():.3e}")
+    assert samplewise_rms.item() < 0.05
+
+    std_err = (x1.std(0) - VAR_1.sqrt()).abs()
+    print(f"transported std {x1.std(0).tolist()} (target {VAR_1.sqrt().tolist()})")
+    assert torch.all(std_err < 0.05)
+
+    mean_err = x1.mean(0).abs()
+    se = x1.std(0) / (n**0.5)
+    assert torch.all(mean_err < 3 * se)
+
+    truth = VAR_1.sqrt() * torch.randn(n, 2, generator=generator)
+    for d in range(2):
+        ks = _ks_statistic(x1[:, d], truth[:, d])
+        print(f"dim {d}: KS statistic {ks.item():.3e}")
+        assert ks.item() < 0.05

--- a/tests/processes/test_parameter_flow_mutli_path.py
+++ b/tests/processes/test_parameter_flow_mutli_path.py
@@ -204,6 +204,101 @@ def test_pinned_loss_rejects_bad_s_shape():
         )
 
 
+def test_pinned_loss_rejects_non_flat_event():
+    class _Event2:
+        event_ndim = 2
+
+    with pytest.raises(ValueError, match="event_ndim"):
+        path_pinned_parameter_flow_loss(
+            _Event2(),
+            x=torch.randn(4, 1),
+            s=torch.rand(4),
+            path=_diagonal_path(),
+            joint_score=OracleScore(_joint_score),
+            spatial_score=OracleScore(_spatial_score),
+        )
+
+
+def test_pinned_loss_rejects_theta_dtheta_shape_mismatch():
+    class _MismatchedPath:
+        def theta(self, s):
+            return s.unsqueeze(-1).expand(*s.shape, 2)
+
+        def dtheta_ds(self, s):
+            return s.unsqueeze(-1)  # (*lead, 1) != theta's (*lead, 2)
+
+    with pytest.raises(ValueError, match="must share a shape"):
+        path_pinned_parameter_flow_loss(
+            _AnalyticPerUnitSPotential(THETA_1 - THETA_0),
+            x=torch.randn(4, 2),
+            s=torch.rand(4),
+            path=_MismatchedPath(),
+            joint_score=OracleScore(_joint_score),
+            spatial_score=OracleScore(_spatial_score),
+        )
+
+
+def test_pinned_loss_rejects_spatial_score_shape_mismatch():
+    with pytest.raises(ValueError, match="spatial_score returned shape"):
+        path_pinned_parameter_flow_loss(
+            _AnalyticPerUnitSPotential(THETA_1 - THETA_0),
+            x=torch.randn(4, 2),
+            s=torch.rand(4),
+            path=_diagonal_path(),
+            joint_score=OracleScore(_joint_score),
+            spatial_score=OracleScore(lambda x, _theta: x[..., :1]),
+        )
+
+
+def test_pinned_loss_accepts_flat_directional_score():
+    # directional_score=True with a score returning the flat (*lead,) shape
+    # is used directly with no tangent contraction.
+    path = _diagonal_path()
+    delta = THETA_1 - THETA_0
+    field = _AnalyticPerUnitSPotential(delta)
+    s = torch.rand(64)
+    x = path.theta(s) + torch.randn(64, 2)
+
+    def flat_directional(x, theta):
+        return (delta * (x - theta)).sum(-1)  # shape (*lead,)
+
+    loss = path_pinned_parameter_flow_loss(
+        field,
+        x=x,
+        s=s,
+        path=path,
+        joint_score=flat_directional,
+        spatial_score=OracleScore(_spatial_score),
+        directional_score=True,
+    )
+    assert loss.item() < 1e-10
+
+
+def test_pinned_loss_rejects_bad_directional_score_shape():
+    with pytest.raises(ValueError, match="directional joint_score must return"):
+        path_pinned_parameter_flow_loss(
+            _AnalyticPerUnitSPotential(THETA_1 - THETA_0),
+            x=torch.randn(4, 2),
+            s=torch.rand(4),
+            path=_diagonal_path(),
+            joint_score=lambda x, _theta: torch.zeros(*x.shape[:-1], 3),
+            spatial_score=OracleScore(_spatial_score),
+            directional_score=True,
+        )
+
+
+def test_pinned_loss_rejects_joint_score_shape_mismatch():
+    with pytest.raises(ValueError, match="joint_score returned shape"):
+        path_pinned_parameter_flow_loss(
+            _AnalyticPerUnitSPotential(THETA_1 - THETA_0),
+            x=torch.randn(4, 2),
+            s=torch.rand(4),
+            path=_diagonal_path(),
+            joint_score=lambda x, _theta: x[..., :1],
+            spatial_score=OracleScore(_spatial_score),
+        )
+
+
 def test_pinned_loss_reduction_modes():
     path = _diagonal_path()
     field = ScalarPotentialField(2, theta_dim=2, hidden=16, layers=2)

--- a/tests/processes/test_parameter_flow_no_oracle.py
+++ b/tests/processes/test_parameter_flow_no_oracle.py
@@ -1,0 +1,244 @@
+r"""End-to-end no-oracle loop: trained score estimators in place of oracles."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+from torch import nn
+
+from nami.components import SinusoidalTimeEmbedding
+from nami.fields.scalar_potential import ScalarPotentialField
+from nami.losses.parameter_flow import parameter_flow_loss
+from nami.losses.score_matching import (
+    denoising_score_matching_loss,
+    time_score_matching_loss,
+)
+from nami.paths import LinearParameterPath
+from nami.scores import CTSMJointScore, DSMSpatialScore, OracleScore
+
+# theta(s) = -0.4 -> +0.4, within the family's validity range;
+# CTSMJointScore is path-locked to this segment.
+THETA_LO, THETA_HI = -0.4, 0.4
+DELTA = THETA_HI - THETA_LO
+
+
+def _p0(x: torch.Tensor) -> torch.Tensor:
+    return torch.exp(-0.5 * x**2) / math.sqrt(2 * math.pi)
+
+
+def _p_theta(x: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+    return _p0(x) * (1 + theta * torch.tanh(x))
+
+
+def _joint_score(x: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+    return torch.tanh(x) / (1 + theta * torch.tanh(x))
+
+
+def _spatial_score(x: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+    sech2 = 1.0 / torch.cosh(x) ** 2
+    return -x + theta * sech2 / (1 + theta * torch.tanh(x))
+
+
+def _v_analytic_on_grid(grid: torch.Tensor, theta: float) -> torch.Tensor:
+    integrand = _p0(grid) * torch.tanh(grid)
+    integral = torch.cat(
+        [torch.zeros(1, dtype=grid.dtype), torch.cumulative_trapezoid(integrand, grid)]
+    )
+    return -integral / _p_theta(grid, torch.tensor(theta, dtype=grid.dtype))
+
+
+def _sample_component(sign: float, n: int, generator: torch.Generator) -> torch.Tensor:
+    """Rejection-sample q_pm = 2 p0(x) sigma(pm 2x) from the N(0,1) proposal."""
+    out = []
+    have = 0
+    while have < n:
+        prop = torch.randn(2 * n + 64, generator=generator)
+        u = torch.rand(prop.shape, generator=generator)
+        acc = prop[u < torch.sigmoid(2 * sign * prop)]
+        out.append(acc)
+        have += acc.numel()
+    return torch.cat(out)[:n]
+
+
+def _simulate(theta: torch.Tensor, generator: torch.Generator):
+    """Draw (x, z) from the mixture; returns x (N,1) and z_pm (N,1) in {-1,+1}."""
+    lam = (1 + theta) / 2
+    z = (torch.rand(theta.shape, generator=generator) < lam).float() * 2 - 1
+    x = torch.empty_like(theta)
+    for sign in (1.0, -1.0):
+        mask = z.squeeze(-1) == sign
+        n = int(mask.sum())
+        if n:
+            x[mask, 0] = _sample_component(sign, n, generator)
+    return x, z
+
+
+def _latent_joint_score(z: torch.Tensor, theta: torch.Tensor) -> torch.Tensor:
+    """Latent score: d/dtheta log p_theta(z) = z / (1 + theta z)."""
+    return z / (1 + theta * z)
+
+
+def test_simulator_matches_marginal():
+    # The mixture sampler must reproduce the analytic marginal (KS check),
+    # and the latent score's posterior mean must equal the marginal joint
+    # score (binned check).
+    generator = torch.Generator().manual_seed(0)
+    theta = torch.full((20000, 1), 0.3)
+    x, z = _simulate(theta, generator)
+
+    # KS against the analytic CDF on a grid.
+    grid = torch.linspace(-8, 8, 4001, dtype=torch.float64)
+    pdf = _p_theta(grid, torch.tensor(0.3, dtype=torch.float64))
+    cdf = torch.cat([torch.zeros(1), torch.cumulative_trapezoid(pdf, grid)])
+    cdf = cdf / cdf[-1]
+    xs = torch.sort(x.squeeze(-1))[0].double()
+    emp = torch.arange(1, xs.numel() + 1, dtype=torch.float64) / xs.numel()
+    idx = torch.searchsorted(grid, xs).clamp(0, grid.numel() - 1)
+    ks = (emp - cdf[idx]).abs().max()
+    assert ks.item() < 0.02
+
+    # Binned conditional mean of the latent score ~= marginal joint score.
+    targets = _latent_joint_score(z, theta).squeeze(-1)
+    edges = torch.linspace(-2.5, 2.5, 26)
+    centres = 0.5 * (edges[:-1] + edges[1:])
+    bins = torch.bucketize(x.squeeze(-1), edges).clamp(1, 25) - 1
+    err = []
+    for b in range(25):
+        sel = bins == b
+        if sel.sum() > 200:
+            binned = targets[sel].mean()
+            truth = _joint_score(centres[b], torch.tensor(0.3))
+            err.append((binned - truth).abs())
+    assert torch.stack(err).mean() < 0.05
+
+
+@pytest.mark.slow
+def test_no_oracle_loop_with_trained_scores():
+    """Samples in, transport out: CTSM + DSM in place of oracle scores.
+
+    Stage metrics are printed so the error propagation (score error ->
+    velocity error) is inspectable.
+    """
+    torch.manual_seed(23)
+    generator = torch.Generator().manual_seed(23)
+    path = LinearParameterPath(torch.tensor([THETA_LO]), torch.tensor([THETA_HI]))
+
+    def draw_theta(n: int) -> torch.Tensor:
+        s = torch.rand(n, generator=generator)
+        return path.theta(s), s
+
+    sigma_dsm = 0.15
+    dsm_net = nn.Sequential(
+        nn.Linear(2, 128), nn.SiLU(), nn.Linear(128, 128), nn.SiLU(), nn.Linear(128, 1)
+    )
+
+    def dsm_wrapped(x, theta):
+        return dsm_net(torch.cat([x, theta], dim=-1))
+
+    opt = torch.optim.Adam(dsm_net.parameters(), lr=1e-3)
+    sched = torch.optim.lr_scheduler.CosineAnnealingLR(opt, T_max=4000, eta_min=1e-5)
+    for _ in range(4000):
+        theta, _ = draw_theta(1024)
+        x, _ = _simulate(theta, generator)
+        loss = denoising_score_matching_loss(
+            dsm_wrapped, x=x, theta=theta, sigma=sigma_dsm
+        )
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+        sched.step()
+    spatial_trained = DSMSpatialScore(dsm_wrapped)
+
+    t_emb = SinusoidalTimeEmbedding(16, max_period=100.0)
+    ts_net = nn.Sequential(
+        nn.Linear(17, 128), nn.SiLU(), nn.Linear(128, 128), nn.SiLU(), nn.Linear(128, 1)
+    )
+
+    def ts_wrapped(x, s):
+        feats = t_emb(s, leading_shape=x.shape[:-1], device=x.device, dtype=x.dtype)
+        return ts_net(torch.cat([x, feats], dim=-1))
+
+    opt = torch.optim.Adam(ts_net.parameters(), lr=1e-3)
+    sched = torch.optim.lr_scheduler.CosineAnnealingLR(opt, T_max=6000, eta_min=1e-5)
+    for _ in range(6000):
+        s = torch.rand(2048, generator=generator)
+        theta = path.theta(s)
+        x, z = _simulate(theta, generator)
+        # d/ds log p = theta-dot * (latent joint score).
+        target = DELTA * _latent_joint_score(z, theta).squeeze(-1)
+        loss = time_score_matching_loss(ts_wrapped, x=x, s=s, target=target)
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+        sched.step()
+    joint_trained = CTSMJointScore(ts_wrapped, path)
+
+    for theta_eval in (-0.3, 0.0, 0.3):
+        n = 8192
+        theta = torch.full((n, 1), theta_eval)
+        x, _ = _simulate(theta, generator)
+        with torch.no_grad():
+            dsm_rms = (
+                (spatial_trained(x, theta) - _spatial_score(x, theta))
+                .pow(2)
+                .mean()
+                .sqrt()
+            )
+            ctsm_rms = (
+                (joint_trained(x, theta) - _joint_score(x, theta)).pow(2).mean().sqrt()
+            )
+        print(
+            f"theta={theta_eval}: DSM spatial RMS {dsm_rms.item():.3e}, "
+            f"CTSM joint RMS {ctsm_rms.item():.3e}"
+        )
+        assert dsm_rms.item() < 0.15
+        assert ctsm_rms.item() < 0.10
+
+    def train_phi(joint, spatial, seed: int) -> ScalarPotentialField:
+        torch.manual_seed(seed)
+        field = ScalarPotentialField(1, theta_dim=1, hidden=64, layers=3)
+        optimizer = torch.optim.Adam(field.parameters(), lr=1e-3)
+        for _ in range(3000):
+            theta, _ = draw_theta(512)
+            x, _ = _simulate(theta, generator)
+            loss = parameter_flow_loss(
+                field, x=x, theta=theta, joint_score=joint, spatial_score=spatial
+            )
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+        return field
+
+    field_no_oracle = train_phi(joint_trained, spatial_trained, seed=7)
+    field_oracle = train_phi(
+        OracleScore(_joint_score), OracleScore(_spatial_score), seed=7
+    )
+
+    grid = torch.linspace(-5.0, 5.0, 801, dtype=torch.float64)
+    for theta_eval in (-0.3, 0.0, 0.3):
+        v_true = _v_analytic_on_grid(grid, theta_eval)
+        xs = grid.float().unsqueeze(-1)
+        thetas = torch.full((grid.numel(), 1), theta_eval)
+        weights = _p_theta(grid, torch.tensor(theta_eval, dtype=grid.dtype))
+        weights = weights / torch.trapezoid(weights, grid)
+
+        def werr(a, b, w=weights):
+            return torch.trapezoid((a - b) ** 2 * w, grid).item()
+
+        v_no = field_no_oracle.velocity(xs, thetas, create_graph=False)
+        v_no = v_no.squeeze(-1).double()
+        v_or = field_oracle.velocity(xs, thetas, create_graph=False)
+        v_or = v_or.squeeze(-1).double()
+
+        e_or = werr(v_or, v_true)
+        e_no = werr(v_no, v_true)
+        e_gap = werr(v_no, v_or)
+        print(
+            f"theta={theta_eval}: oracle {e_or:.3e}, NO-ORACLE {e_no:.3e}, "
+            f"gap {e_gap:.3e}"
+        )
+        assert e_or < 1e-3
+        assert e_no < 1e-2
+        assert e_gap < 1e-2

--- a/tests/scores/test_scores.py
+++ b/tests/scores/test_scores.py
@@ -112,6 +112,25 @@ def test_ctsm_multitheta_directional_returns_scalar():
     torch.testing.assert_close(out.squeeze(-1), 3.0 * s)
 
 
+def test_ctsm_dim1_accepts_flat_time_score():
+    # A net returning shape (*lead,) (no trailing 1) is promoted to
+    # (*lead, 1) before the chain-rule division.
+    path = LinearParameterPath(torch.tensor([0.0]), torch.tensor([2.0]))
+    ctsm = CTSMJointScore(lambda _x, s: 4.0 * s, path)
+    s = torch.tensor([0.25, 0.5])
+    theta = path.theta(s)
+    out = ctsm(torch.randn(2, 1), theta)
+    assert out.shape == (2, 1)
+    torch.testing.assert_close(out.squeeze(-1), 4.0 * s / 2.0)
+
+
+def test_ctsm_degenerate_path_raises():
+    path = LinearParameterPath(torch.tensor([1.0]), torch.tensor([1.0]))
+    ctsm = CTSMJointScore(lambda x, _s: x, path)
+    with pytest.raises(ValueError, match="degenerate path"):
+        ctsm(torch.randn(2, 1), torch.ones(2, 1))
+
+
 def test_ctsm_non_linear_path_raises_not_implemented():
     class _DummyPath:
         def theta(self, s):

--- a/tests/scores/test_scores.py
+++ b/tests/scores/test_scores.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from nami.paths import LinearParameterPath
+from nami.scores import (
+    CTSMJointScore,
+    DSMSpatialScore,
+    MinedJointScore,
+    OracleScore,
+    ScoreEstimator,
+)
+
+
+def test_oracle_wraps_callable():
+    oracle = OracleScore(lambda x, theta: x * theta)
+    x = torch.randn(4, 1)
+    theta = torch.randn(4, 1)
+    torch.testing.assert_close(oracle(x, theta), x * theta)
+
+
+def test_oracle_satisfies_protocol():
+    assert isinstance(OracleScore(lambda x, _theta: x), ScoreEstimator)
+
+
+def test_mined_joint_delegates():
+    calls = []
+
+    def simulator_score(x, theta):
+        calls.append((x, theta))
+        return torch.zeros_like(theta)
+
+    mined = MinedJointScore(simulator_score)
+    x = torch.randn(3, 2)
+    theta = torch.randn(3, 1)
+    out = mined(x, theta)
+
+    assert isinstance(mined, ScoreEstimator)
+    assert out.shape == (3, 1)
+    assert len(calls) == 1
+
+
+def test_dsm_spatial_wraps_net_and_satisfies_protocol():
+    dsm = DSMSpatialScore(lambda x, theta: theta - x)
+    assert isinstance(dsm, ScoreEstimator)
+    x = torch.randn(5, 2)
+    theta = torch.randn(5, 2)
+    torch.testing.assert_close(dsm(x, theta), theta - x)
+
+
+def test_ctsm_satisfies_protocol():
+    path = LinearParameterPath(torch.tensor([0.0]), torch.tensor([1.0]))
+    ctsm = CTSMJointScore(lambda x, _s: x.sum(-1, keepdim=True), path)
+    assert isinstance(ctsm, ScoreEstimator)
+
+
+def test_ctsm_dim1_chain_rule():
+    path = LinearParameterPath(torch.tensor([0.0]), torch.tensor([2.0]))
+    delta = 2.0
+
+    def time_net(x, s):
+        theta = path.theta(s)
+        return delta * (x - theta)
+
+    ctsm = CTSMJointScore(time_net, path)
+    theta = torch.tensor([[0.5], [1.0], [1.5]])
+    x = torch.randn(3, 1)
+    out = ctsm(x, theta)
+    assert out.shape == (3, 1)
+    torch.testing.assert_close(out, x - theta)
+
+
+def test_ctsm_recovers_s_from_theta_on_path():
+    # A net that echoes its s argument surfaces the path inversion through
+    # __call__: feeding theta(s_true) back must recover s_true.
+    path = LinearParameterPath(torch.tensor([1.0, -1.0]), torch.tensor([3.0, 1.0]))
+    s_true = torch.tensor([0.0, 0.25, 0.5, 1.0])
+    theta = path.theta(s_true)
+    ctsm = CTSMJointScore(lambda _x, s: s.unsqueeze(-1), path, directional=True)
+    out = ctsm(torch.randn(4, 2), theta)
+    torch.testing.assert_close(out.squeeze(-1), s_true)
+
+
+def test_ctsm_rejects_off_segment_theta():
+    path = LinearParameterPath(torch.tensor([0.0, 0.0]), torch.tensor([1.0, 1.0]))
+    ctsm = CTSMJointScore(lambda x, _s: x, path, directional=True)
+    off = torch.tensor([[0.5, -0.5]])
+    with pytest.raises(ValueError, match="not on the training path"):
+        ctsm(torch.randn(1, 2), off)
+
+
+def test_ctsm_multitheta_raises_without_directional_flag():
+    path = LinearParameterPath(torch.tensor([0.0, 0.0]), torch.tensor([1.0, 1.0]))
+    ctsm = CTSMJointScore(lambda _x, s: torch.zeros_like(s).unsqueeze(-1), path)
+    theta = path.theta(torch.tensor([0.3, 0.6]))
+    with pytest.raises(ValueError, match="cannot recover the full joint score"):
+        ctsm(torch.randn(2, 2), theta)
+
+
+def test_ctsm_multitheta_directional_returns_scalar():
+    path = LinearParameterPath(torch.tensor([0.0, 0.0]), torch.tensor([1.0, 1.0]))
+
+    def time_net(_x, s):
+        return (3.0 * s).unsqueeze(-1)
+
+    ctsm = CTSMJointScore(time_net, path, directional=True)
+    s = torch.tensor([0.2, 0.7])
+    theta = path.theta(s)
+    out = ctsm(torch.randn(2, 2), theta)
+    assert out.shape == (2, 1)
+    torch.testing.assert_close(out.squeeze(-1), 3.0 * s)
+
+
+def test_ctsm_non_linear_path_raises_not_implemented():
+    class _DummyPath:
+        def theta(self, s):
+            return s.unsqueeze(-1)
+
+        def dtheta_ds(self, s):
+            return torch.ones_like(s).unsqueeze(-1)
+
+    ctsm = CTSMJointScore(lambda x, _s: x, _DummyPath())
+    with pytest.raises(NotImplementedError, match="LinearParameterPath"):
+        ctsm(torch.randn(2, 1), torch.randn(2, 1))

--- a/tests/scores/test_scores.py
+++ b/tests/scores/test_scores.py
@@ -124,6 +124,35 @@ def test_ctsm_dim1_accepts_flat_time_score():
     torch.testing.assert_close(out.squeeze(-1), 4.0 * s / 2.0)
 
 
+def test_ctsm_rejects_collinear_out_of_segment_theta():
+    # theta = [2, 2] is collinear with the unit path [0,0]->[1,1] (recon
+    # is exact), but maps to s = 2, outside the trained [0, 1] segment.
+    path = LinearParameterPath(torch.tensor([0.0, 0.0]), torch.tensor([1.0, 1.0]))
+    ctsm = CTSMJointScore(lambda _x, s: s.unsqueeze(-1), path, directional=True)
+    off = torch.tensor([[2.0, 2.0]])
+    with pytest.raises(ValueError, match="outside the trained segment"):
+        ctsm(torch.randn(1, 2), off)
+
+
+def test_ctsm_rejects_negative_out_of_segment_theta():
+    path = LinearParameterPath(torch.tensor([0.0]), torch.tensor([2.0]))
+    ctsm = CTSMJointScore(lambda _x, s: s, path)
+    # theta = -1 -> s = -0.5, before the segment start.
+    with pytest.raises(ValueError, match="outside the trained segment"):
+        ctsm(torch.randn(1, 1), torch.tensor([[-1.0]]))
+
+
+def test_ctsm_rejects_bad_net_output_shape():
+    # A net whose last dim is neither absent nor 1 (here d=2) used to be
+    # silently unsqueezed to (*lead, 2, 1); now it raises.
+    path = LinearParameterPath(torch.tensor([0.0]), torch.tensor([2.0]))
+    ctsm = CTSMJointScore(lambda x, _s: x.expand(*x.shape[:-1], 2), path)
+    s = torch.tensor([0.25, 0.5])
+    theta = path.theta(s)
+    with pytest.raises(ValueError, match="time-score net returned shape"):
+        ctsm(torch.randn(2, 1), theta)
+
+
 def test_ctsm_degenerate_path_raises():
     path = LinearParameterPath(torch.tensor([1.0]), torch.tensor([1.0]))
     ctsm = CTSMJointScore(lambda x, _s: x, path)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import pytest
 import torch
 
+from nami import RK4, ExactDivergence, FlowMatching, StandardNormal
 from nami.diagnostics import (
     describe,
     divergence_stats,
     field_stats,
     reversibility_error,
+    score_projection,
 )
 
 
@@ -215,3 +217,38 @@ def test_reversibility_error_supports_scalar_event_ndim_zero_with_steps_solver()
     torch.testing.assert_close(stats["mean"], torch.tensor(0.0))
     torch.testing.assert_close(stats["std"], torch.tensor(0.0))
     torch.testing.assert_close(stats["max"], torch.tensor(0.0))
+
+
+class _ConstantContextField:
+    """Velocity equal to the context: the flow is the shift x -> x + c."""
+
+    event_ndim = 1
+
+    def __call__(
+        self, x: torch.Tensor, t: torch.Tensor, c: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        _ = t
+        if c is None:
+            return torch.zeros_like(x)
+        return (x * 0) + c
+
+
+def test_score_projection_matches_analytic_toy() -> None:
+    process = FlowMatching(
+        _ConstantContextField(),
+        StandardNormal(event_shape=(2,)),
+        RK4(steps=2),
+    )()
+    x = torch.randn(5, 2)
+    theta = torch.randn(5, 2)
+
+    score = score_projection(
+        process,
+        x,
+        theta,
+        estimator=ExactDivergence(max_dim=8, create_graph=True),
+    )
+
+    assert score.shape == theta.shape
+    assert torch.allclose(score, x - theta, atol=1e-5)
+    assert not theta.requires_grad  # caller's tensor untouched

--- a/tests/test_flow_matching.py
+++ b/tests/test_flow_matching.py
@@ -144,6 +144,47 @@ def test_sample_return_logp_matches_separate_log_prob():
     assert torch.allclose(log_prob, expected, atol=2e-3, rtol=2e-3)
 
 
+def test_log_prob_c_override_matches_bound_context():
+    # The c= override is evaluation-scoped conditioning: a process bound
+    # with context must agree with an unconditional bind overridden at
+    # log_prob time.
+    context = torch.randn(5, 2)
+    x = torch.randn(5, 2)
+    lazy = FlowMatching(
+        PlainField(),
+        StandardNormal(event_shape=(2,)),
+        RK4(steps=2),
+    )
+    estimator = ExactDivergence(max_dim=8)
+
+    bound = lazy(context).log_prob(x, estimator=estimator)
+    overridden = lazy().log_prob(x, c=context, estimator=estimator)
+
+    assert torch.allclose(bound, overridden)
+
+
+def test_log_prob_c_override_is_autograd_leaf():
+    # PlainField's velocity is the constant c, so the flow is the shift
+    # x -> x - c and log p_c(x) = log N(x - c; 0, I) exactly (RK4 is
+    # exact on constants).  Hence grad_c log p_c(x) = x - c — conditioning
+    # passed as a function argument, not bind-time context.
+    theta = torch.randn(5, 2, requires_grad=True)
+    x = torch.randn(5, 2)
+    process = FlowMatching(
+        PlainField(),
+        StandardNormal(event_shape=(2,)),
+        RK4(steps=2),
+    )()
+
+    log_prob = process.log_prob(
+        x, c=theta, estimator=ExactDivergence(max_dim=8, create_graph=True)
+    )
+    (grad_theta,) = torch.autograd.grad(log_prob.sum(), theta)
+
+    assert grad_theta.shape == theta.shape
+    assert torch.allclose(grad_theta, x - theta.detach(), atol=1e-5)
+
+
 class LearnableScaleField(nn.Module):
     event_ndim = 1
 


### PR DESCRIPTION
### Description

This PR adds functionality to allow for models that sample from p_theta0 to p_theta1 by integrating the gradient of a trained scalar potential along a path in parameter space, solving the continuity equation in elliptic (curl-free Otto-horizontal) form.


 - `LinearParameterPath` with theta(s) / dtheta_ds(s).
 -  A common `ScoreEstimator` protocol with `Oracle`, `Mined`, `DSMSpatialScore`, and `CTSMJointScore` (path inverting time-score --> joint score, with fallback for dtheta more than one).
- A scalar-potential field MLP head, with velocity via autograd and a grad-field adapter so the loss's
  Laplacian and the runtime log-prob divergence still share the nami.divergence estimator.
- `parameter_flow_loss` squared PDE residual for dim theta = 1
- `path_pinned_parameter_flow_loss` path-projected scalar residual for any d_theta.
- `denoising_score_matching_loss`, `ctsm_loss` (Yu et al. 2025), `time_score_matching_loss`.
-  lazy `ParameterFlow` binding a path at call time with transport, transport_with_logp (diagnostic change-of-variables), and score_supply (PDE inversion), with automatic pinned-mode selection for multi-theta paths.
  - New diagnostic
---


- [x] docstring format (in follow-up)
- [x] decide whether to include experiment notebooks in follow-up or this PR
   - experiments to follow, but at some point [this.](https://github.com/LeviSamuelEvans/nami/issues/26)
- [x] patch coverage
- [x] add missing references
- [x] CTSM formulation