### PR TITLE
chore: add nami_toys back to build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ pre-commit = "*"
 
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/nami"] ###"src/nami_toys"
+packages = ["src/nami", "src/nami_toys"]
 
 [tool.hatch.version]
 source = "vcs"


### PR DESCRIPTION
adding the toys subpackage back to the build for easier use in other projects.